### PR TITLE
treatment of backslashes in `vue_integration()`

### DIFF
--- a/src/Elements.jl
+++ b/src/Elements.jl
@@ -26,6 +26,7 @@ end
 function vue_integration(model::M; vue_app_name::String, endpoint::String, channel::String)::String where {M<:ReactiveModel}
   vue_app = replace(Genie.Renderer.Json.JSONParser.json(model |> Stipple.render), "\"{" => " {")
   vue_app = replace(vue_app, "}\"" => "} ")
+  vue_app = replace(vue_app, "\\\\" => "\\")
 
   output = "var $vue_app_name = new Vue($vue_app);\n\n"
 

--- a/src/Stipple.jl
+++ b/src/Stipple.jl
@@ -288,7 +288,7 @@ function camelcase(s::String) :: String
 end
 
 function Core.NamedTuple(kwargs::Dict) :: NamedTuple
-  NamedTuple{collect(keys(kwargs)) |> Tuple}(collect(values(kwargs)))
+  NamedTuple{Tuple(keys(kwargs))}(collect(values(kwargs)))
 end
 
 function Core.NamedTuple(kwargs::Dict, property::Symbol, value::String) :: NamedTuple


### PR DESCRIPTION
I tried to use the js function `this.$watch()` in `js_methods()`.
It seems that the handling of backslashes is not correct. I added a `"\\\\" => "\\"` replacement rule and now it works fine.

My use case was a watchonce method:
```
function Stipple.js_methods(HHDashboard2)
  raw"""
      download: function(filename) {
	  this.filename = filename;
	  // trigger the backend to calculate a string that shall be downloaded as a file
	  this.downloadtext = "request download";
          // watch for the content to be passed in `this.downloadtext`
	  this.unwatch = this.\$watch("downloadtext", this.pushDownload);
	  },
    pushDownload: function(newvalue) {
	  if (newvalue == "" || newvalue == "request download") { return }

	  var element = document.createElement('a');
	  element.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(this.downloadtext));
	  element.setAttribute('download', this.filename);
	  element.style.display = 'none';
	  document.body.appendChild(element);
	  element.click();
	  document.body.removeChild(element);

	  this.unwatch();
	  this.download = '';
	  }
  """
end
```
