### PR TITLE
broadcast changes to other clients

### DIFF
--- a/src/Stipple.jl
+++ b/src/Stipple.jl
@@ -156,7 +156,7 @@ function init(model::M, ui::Union{String,Vector} = ""; vue_app_name::String = St
           try
             Genie.WebChannels.message(client, msg)
           catch ex
-            @error "Error in broadcasting to other clients"
+            @error "Error $ex in broadcasting to $client"
           end
         end
       end


### PR DESCRIPTION
Currently changes in one client are reflected in the backend via the channel route "watchers" in `Stipple.init()`.
However, the changes don't trigger another broadcast inorder to prevent a ping-pong. So all other clients need to be informed by the watcher routine.
Implementation is straight forward: send a message to all connected clients except oneself.