### PR TITLE
Improve multi-user mode, prevent watcher loops, improve payload parsing

### DIFF
--- a/src/Elements.jl
+++ b/src/Elements.jl
@@ -30,7 +30,39 @@ function vue_integration(model::M; vue_app_name::String, endpoint::String, chann
   vue_app = replace(vue_app, "}\"" => "} ")
   vue_app = replace(vue_app, "\\\\" => "\\")
 
-  output = "var $vue_app_name = new Vue($vue_app);\n\n"
+  output = raw"""
+    const watcherMixin = {
+      methods: {
+        \$withoutWatchers: function (cb, filter) {
+          var ww = (filter == null) ? this._watchers : []
+          if (typeof(filter) == "string") {
+            this._watchers.forEach((w) => { if (w.expression == filter) {ww.push(w)} } )
+          } else { // if it is a true regex
+            this._watchers.forEach((w) => { if (w.expression.match(filter)) {ww.push(w)} } )
+          }
+
+          const watchers = ww.map((watcher) => ({ cb: watcher.cb, sync: watcher.sync }))
+
+          for (let index in ww) {
+            ww[index].cb = () => null
+            ww[index].sync = true
+          }
+
+          cb()
+
+          for (let index in ww) {
+            ww[index].cb = watchers[index].cb
+            ww[index].sync = watchers[index].sync
+          }
+        },
+        updateField: function (field, newVal) {
+          this.\$withoutWatchers( () => {this[field] = newVal }, "function () {return this." + field + "}")
+        }
+      }
+    }
+    """
+
+  output *= "\nvar $vue_app_name = new Vue($vue_app);\n\n"
 
   for field in fieldnames(typeof(model))
     output *= Stipple.watch(vue_app_name, getfield(model, field), field, channel, debounce, model)
@@ -40,23 +72,11 @@ function vue_integration(model::M; vue_app_name::String, endpoint::String, chann
 
     window.parse_payload = function(payload){
       if (payload.key) {
-        let ww = [];
-        window.$(vue_app_name)._watchers.forEach( (w) => { if (w.expression == payload.key) { ww.push(w) } } );
+        window.$(vue_app_name).updateField(payload.key, payload.value)
 
-        const watchers = ww.map((watcher) => ({ cb: watcher.cb, sync: watcher.sync }));
-
-        for (let index in ww) {
-          ww[index].cb = () => null;
-          ww[index].sync = true
-        }
-
-        window.$(vue_app_name)[payload.key] = payload.value;
-        window.console.log("server update: ", payload.key + ': ' + payload.value);
-
-        for (let index in ww) {
-          ww[index].cb = watchers[index].cb;
-          ww[index].sync = watchers[index].sync
-        }
+        let vStr = payload.value.toString()
+        vStr = vStr.length < 60 ? vStr : vStr.substring(0, 55) + ' ...'
+        window.console.log("server update: ", payload.key + ': ' + vStr)
       } else {
         window.console.log("server says: ", payload)
       }

--- a/src/Elements.jl
+++ b/src/Elements.jl
@@ -51,14 +51,14 @@ function vue_integration(model::M; vue_app_name::String, endpoint::String, chann
         }
 
         window.$(vue_app_name)[payload.key] = payload.value;
-        window.console.log("ws update: ", payload.key + ': ' + payload.value);
+        window.console.log("server update: ", payload.key + ': ' + payload.value);
 
         for (let index in ww) {
           ww[index].cb = watchers[index].cb;
           ww[index].sync = watchers[index].sync
         }
       } else {
-        window.console.log("ws update: ", payload)
+        window.console.log("server says: ", payload)
       }
     }
     """

--- a/src/Elements.jl
+++ b/src/Elements.jl
@@ -34,7 +34,7 @@ function vue_integration(model::M; vue_app_name::String, endpoint::String, chann
     const watcherMixin = {
       methods: {
         \$withoutWatchers: function (cb, filter) {
-          var ww = (filter == null) ? this._watchers : []
+          let ww = (filter == null) ? this._watchers : []
           if (typeof(filter) == "string") {
             this._watchers.forEach((w) => { if (w.expression == filter) {ww.push(w)} } )
           } else { // if it is a true regex

--- a/src/Elements.jl
+++ b/src/Elements.jl
@@ -39,21 +39,27 @@ function vue_integration(model::M; vue_app_name::String, endpoint::String, chann
   output *= """
 
     window.parse_payload = function(payload){
-        let ww = window.$(vue_app_name)._watchers
-        const watchers = ww.map((watcher) => ({ active: watcher.active, sync: watcher.sync }));
+      if (payload.key) {
+        let ww = [];
+        window.$(vue_app_name)._watchers.forEach( (w) => { if (w.expression == payload.key) { ww.push(w) } } );
+
+        const watchers = ww.map((watcher) => ({ cb: watcher.cb, sync: watcher.sync }));
 
         for (let index in ww) {
-          ww[index].active = false;
+          ww[index].cb = () => null;
           ww[index].sync = true
         }
 
         window.$(vue_app_name)[payload.key] = payload.value;
-        window.console.log("ws update: ", (payload instanceof Object) ? payload.key + ': ' + payload.value : "'" + payload + "'");
+        window.console.log("ws update: ", payload.key + ': ' + payload.value);
 
         for (let index in ww) {
-          ww[index].active = watchers[index].active;
+          ww[index].cb = watchers[index].cb;
           ww[index].sync = watchers[index].sync
         }
+      } else {
+        window.console.log("ws update: ", payload)
+      }
     }
     """
 end

--- a/src/Stipple.jl
+++ b/src/Stipple.jl
@@ -163,7 +163,6 @@ function init(model::M, ui::Union{String,Vector} = ""; vue_app_name::String = St
 
       # if update was necessary, broadcast to other clients
       if value_changed && MULTI_USER_MODE
-        @info "multi-user-mode!"
         ws_client = Genie.Router.@params(:WS_CLIENT)
         c_clients = getfield.(Genie.WebChannels.connected_clients(channel), :client)
         other_clients = setdiff(c_clients, [ws_client])

--- a/src/Stipple.jl
+++ b/src/Stipple.jl
@@ -277,9 +277,10 @@ end
 const DEPS = Function[]
 
 function deps(channel::String = Genie.config.webchannels_default_route) :: String
-  Genie.Router.route("/js/stipple/vue.js") do
+  vuejs = Genie.Configuration.isprod() ? "vue.min.js" : "vue.js"
+  Genie.Router.route("/js/stipple/$vuejs") do
     Genie.Renderer.WebRenderable(
-      read(joinpath(@__DIR__, "..", "files", "js", "vue.js"), String),
+      read(joinpath(@__DIR__, "..", "files", "js", vuejs), String),
       :javascript) |> Genie.Renderer.respond
   end
 
@@ -305,7 +306,7 @@ function deps(channel::String = Genie.config.webchannels_default_route) :: Strin
   string(
     Genie.Assets.channels_support(channel),
     Genie.Renderer.Html.script(src="/js/stipple/underscore-min.js"),
-    Genie.Renderer.Html.script(src="/js/stipple/vue.js"),
+    Genie.Renderer.Html.script(src="/js/stipple/$vuejs"),
     join([f() for f in DEPS], "\n"),
     Genie.Renderer.Html.script(src="/js/stipple/stipplecore.js"),
     Genie.Renderer.Html.script(src="/js/stipple/vue_filters.js"),

--- a/src/Stipple.jl
+++ b/src/Stipple.jl
@@ -107,7 +107,7 @@ end
 function watch(vue_app_name::String, fieldtype::Any, fieldname::Symbol, channel::String, debounce::Int, model::M)::String where {M<:ReactiveModel}
   js_channel = channel == "" ? "window.Genie.Settings.webchannels_default_route" : "'$channel'"
   string(vue_app_name, raw".\$watch('", fieldname, "', _.debounce(function(newVal, oldVal){
-    window.console.log('ws to server: $fieldname: ' + newval);
+    window.console.log('ws to server: $fieldname: ' + newVal);
     Genie.WebChannels.sendMessageTo($js_channel, 'watchers', {'payload': {'field':'$fieldname', 'newval': newVal, 'oldval': oldVal}});
   }, $debounce));\n\n")
 end

--- a/src/Stipple.jl
+++ b/src/Stipple.jl
@@ -202,7 +202,9 @@ function setup(model::M, channel = Genie.config.webchannels_default_route)::M wh
     isa(getproperty(model, f), Reactive) || continue
 
     on(getproperty(model, f)) do v
-      @info "broadcast to $channel: $f => $(repr(hh, context = :limit => true))"
+      vstr = repr(v, context = :limit => true)
+      vstr = length(vstr) <= 60 ? vstr : vstr[1:56] * " ..."
+      @info "broadcast to $channel: $f => $vstr"
       push!(model, f => v, channel = channel)
     end
   end


### PR DESCRIPTION
Three points have been addressed:
- multi-user mode:
the stipple.js route has been moved to the ws channel, if the channel differs from default. This is necessary, as otherwise the data in the model definition would always use the values of the latest client that joined.
I put `@asysnc` in front of `update!(model, field, newvalue, oldvalue)` to enhance responsiveness of the server. Otherwise all observables that are triggered by the update fire and are handled before the ws channel continues. Rewind, if you think, you always want synchronous handling. We could also think about including an argument `sync` in payload...
Also for the sync reason, I moved the `update!()` after the broadcast to the other clients in multi-user-mode. 

- prevent watcher loops:
normally Vue.js's watchers always fire when an update arrives via webchannel. This can lead to enhanced traffic or even loops with more than one client per channel. I chose [@abellion's](https://github.com/vuejs/vue/issues/1829#issuecomment-624193371)  proposal to detach and reattach the watchers. (I didn't use the mixing approach, though.) I also added some log comments to make sure, the communication is going ok

- payload parsing
Base.parse(valtype, arg) needs a String argument. It can fail, if an Integer needs to be converted to a Float. Therefore I first try `convert` and then `Base.parse(valtype, string(arg))`

With all these changes I can use multiple users and mutliple clients per user. If `multi-user-mode == true` all clients of the same user synchronise.