### PR TITLE
Hh new reactive

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Stipple"
 uuid = "4acbeb90-81a0-11ea-1966-bdaff8155998"
 authors = ["Adrian <e@essenciary.com>"]
-version = "0.9.8"
+version = "0.9.9-DEV"
 
 [deps]
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"

--- a/src/Elements.jl
+++ b/src/Elements.jl
@@ -29,7 +29,7 @@ const vm = root
 function vue_integration(model::M; vue_app_name::String, endpoint::String, channel::String, debounce::Int)::String where {M<:ReactiveModel}
   vue_app = replace(Genie.Renderer.Json.JSONParser.json(model |> Stipple.render), "\"{" => " {")
   vue_app = replace(vue_app, "}\"" => "} ")
-  vue_app = replace(vue_app, '"' => "'")
+  # vue_app = replace(vue_app, '"' => "'")
 
   output = raw"""
     const watcherMixin = {
@@ -64,6 +64,25 @@ function vue_integration(model::M; vue_app_name::String, endpoint::String, chann
         }
       }
     }
+    const reviveMixin = {
+      methods: {
+        revive_payload: function(obj) {
+          if (typeof obj === 'object') {
+            for (var key in obj) {
+              if ( (typeof obj[key] === 'object') && !(obj[key].jsfunction) ) {
+                this.revive_payload(obj[key])
+              } else {
+                if (obj[key].jsfunction) {
+                  obj[key] = Function(obj[key].jsfunction.arguments, obj[key].jsfunction.body)
+                  if (key=='stipplejs') { obj[key](); }
+                }
+              }
+            }
+          }
+          return obj;
+        }
+      }
+    }
     """
 
   output *= "\nvar $vue_app_name = new Vue($vue_app);\n\n"
@@ -76,6 +95,7 @@ function vue_integration(model::M; vue_app_name::String, endpoint::String, chann
 
   window.parse_payload = function(payload){
     if (payload.key) {
+      window.$(vue_app_name).revive_payload(payload)
       window.$(vue_app_name).updateField(payload.key, payload.value);
     }
   }
@@ -85,8 +105,8 @@ function vue_integration(model::M; vue_app_name::String, endpoint::String, chann
     $vue_app_name.\$forceUpdate();
   }
   """
-
-  output = replace(replace(repr(output), r"\\'"=>"'"), "'" => '"')
+  # output = replace(replace(repr(output), r"\\'"=>"'"), "'" => '"')
+  output = repr(output)
 
   output[2:prevind(output, lastindex(output))]
 end

--- a/src/Elements.jl
+++ b/src/Elements.jl
@@ -126,7 +126,7 @@ end
 #===#
 
 macro iif(expr)
-  :( :( "v-if='$($(esc(expr)))'" ) )
+  :( "v-if='$($(esc(expr)))'" )
 end
 
 macro elsiif(expr)

--- a/src/Elements.jl
+++ b/src/Elements.jl
@@ -92,8 +92,13 @@ function vue_integration(model::M; vue_app_name::String, endpoint::String, chann
 
     ,
 
-    join([Stipple.watch(vue_app_name, getfield(model, field), field, channel, debounce, model) for field in fieldnames(typeof(model))])
-
+    join([Stipple.watch(vue_app_name, getfield(model, field), field, channel, debounce, model) 
+      for field in fieldnames(typeof(model))
+      if !(endswith(String(field), "_private") || 
+        getfield(model, field) isa Reactive && getfield(model, field).mode != :public || 
+        getfield(model, field) isa Private)
+    ])
+    
     ,
 
     """
@@ -110,7 +115,8 @@ function vue_integration(model::M; vue_app_name::String, endpoint::String, chann
       console.log("Loading completed");
       $vue_app_name.\$forceUpdate();
     }
-    """
+  }
+  """
   ) |> repr
 
   

--- a/src/Stipple.jl
+++ b/src/Stipple.jl
@@ -14,6 +14,7 @@ using Logging, Reexport
 @reexport using Genie
 @reexport using Genie.Renderer.Html
 import Genie.Renderer.Json.JSONParser: JSONText, json
+export JSONText
 
 import Genie.Configuration: isprod, PROD, DEV
 


### PR DESCRIPTION
New Reactive API which is backwards compatible but introduces public, private, readonly and jsfunctions modes for model fields.

 I create this PR to discuss the potential changes.

Current state:
- Variables with names ending with `_private` are excluded from the frontend.
- `Private{T}` is introduced as wrapper type for fields that don't go into the frontend, but I'm not sure whether this is the optimal solution
- `Reactive{T}` becomes a mutable struct with a mode field. `:public` is default and is identical to the current implementation, `:private` is excluded from the frontend. `:readonly` does not receive a watcher in the frontend. (Currently it can manually be changed from the frontend, but we should prevent that in the future). `:jsfunction` indicates that the variable contains either a JSONText with a js function or a `Dict` that possibly contains a js function. This variables are (currently) readonly.

Some background to js functions: 
- Why should we have it?
Sometimes it is very convenient to execute js functions in the frontend, e.g. for messenging, debugging or complex animations. Secondly, Apexcharts uses functions for axis formatting. (It is at least the only way I found to change the number of decimals in axis labels.)
- What is special about functions?
If js functions are initialised in the data section, they need to be defined with some `JSONText`, which is straight forward. But the dynamic change of a js function is tricky, as JSON does not provide a standard format. I have defined my own format after various inspiring readings and use the `revive` option in the json parser to construct functions in the frontend. This is invisible to the user and happens either in the `push!(model, ...)`routine or in the reactive listener that is attached during model setup.

Tasks to be done:
- `update!` needs to differentiate whether a property is private or not (see `setindex!` ...)
- readonly properties can currently be changed manually
- a switch enableing/disabling js function reviver
- support a selection of keys, e.g. a dictionary of regex patterns, for which the reviver is enabled

Proposal for other changes:
- use `setindex!` to change array parameters with notification and define a special method to replace the current setindex method
- modify the listener to better handle typed arrays
