### PR TITLE
change parsing

### DIFF
--- a/src/Stipple.jl
+++ b/src/Stipple.jl
@@ -181,7 +181,7 @@ export @kwredef
 function __init__()
   Genie.config.websockets_server = true
   @require OffsetArrays  = "6fe1bfb0-de20-5000-8ca7-80f57d26f881" function convertvalue(targetfield::Union{Ref{T}, Reactive{T}}, value) where T <: OffsetArrays.OffsetArray
-    a = stippleparse(eltype(targetfield), value)
+    a = stipple_parse(eltype(targetfield), value)
 
     # if value is not an OffsetArray use the offset of the current array
     if ! isa(value, OffsetArrays.OffsetArray)
@@ -534,7 +534,7 @@ include("Layout.jl")
 #===#
 
 function convertvalue(targetfield::Any, value)
-  stippleparse(eltype(targetfield), value)
+  stipple_parse(eltype(targetfield), value)
 end
 
 """
@@ -593,29 +593,29 @@ end
 #===#
 
 # wrapper around Base.parse to prevent type piracy
-stippleparse(::Type{T}, value) where T = Base.parse(T, value)
+stipple_parse(::Type{T}, value) where T = Base.parse(T, value)
 
-function stippleparse(::Type{T}, value::Dict) where T <: AbstractDict
+function stipple_parse(::Type{T}, value::Dict) where T <: AbstractDict
   convert(T, value)
 end
 
-function stippleparse(::Type{T}, value::Dict) where {Tval, T <: AbstractDict{Symbol, Tval}}
+function stipple_parse(::Type{T}, value::Dict) where {Tval, T <: AbstractDict{Symbol, Tval}}
   T(zip(Symbol.(string.(keys(value))), values(value)))
 end
 
-function stippleparse(::Type{<:AbstractFloat}, value::T) where T <: Integer
+function stipple_parse(::Type{<:AbstractFloat}, value::T) where T <: Integer
   convert(valtype, value)
 end
 
-function stippleparse(::Type{T1}, value::T2) where {T1 <: AbstractArray, T2 <: AbstractArray}
+function stipple_parse(::Type{T1}, value::T2) where {T1 <: AbstractArray, T2 <: AbstractArray}
   convert(T1, value)
 end
 
-function stippleparse(::Type{T}, value) where T <: AbstractArray
+function stipple_parse(::Type{T}, value) where T <: AbstractArray
   convert(T, eltype(T)[value])
 end
 
-function stippleparse(::Type{T}, v::T) where {T}
+function stipple_parse(::Type{T}, v::T) where {T}
   v::T
 end
 

--- a/src/Stipple.jl
+++ b/src/Stipple.jl
@@ -599,6 +599,10 @@ function stippleparse(::Type{T}, value::Dict) where T <: AbstractDict
   convert(T, value)
 end
 
+function stippleparse(::Type{T}, value::Dict) where {Tval, T <: AbstractDict{Symbol, Tval}}
+  T(zip(Symbol.(string.(keys(value))), values(value)))
+end
+
 function stippleparse(::Type{<:AbstractFloat}, value::T) where T <: Integer
   convert(valtype, value)
 end

--- a/src/Stipple.jl
+++ b/src/Stipple.jl
@@ -181,17 +181,15 @@ export @kwredef
 function __init__()
   Genie.config.websockets_server = true
   @require OffsetArrays  = "6fe1bfb0-de20-5000-8ca7-80f57d26f881" function convertvalue(targetfield::Union{Ref{T}, Reactive{T}}, value) where T <: OffsetArrays.OffsetArray
-    valtype = eltype(targetfield)
-    a = if value isa AbstractArray
-      convert(Array{eltype(valtype)}, value)
-    else
-      eltype(valtype)[value]
-    end
+    a = stippleparse(eltype(targetfield), value)
+
+    # if value is not an OffsetArray use the offset of the current array
     if ! isa(value, OffsetArrays.OffsetArray)
       o = targetfield[].offsets
       OffsetArrays.OffsetArray(a, OffsetArrays.Origin(1 .+ o))
+    # otherwise use the existing value
     else
-      value
+      a
     end
   end
 end
@@ -536,19 +534,7 @@ include("Layout.jl")
 #===#
 
 function convertvalue(targetfield::Any, value)
-  valtype = eltype(targetfield)
-
-  if valtype <: AbstractFloat && typeof(value) <: Integer
-    convert(valtype, value)
-  elseif valtype <: AbstractArray
-    if value isa AbstractArray
-      convert(Array{eltype(valtype)}, value)
-    else
-      eltype(valtype)[value]
-    end
-  else
-    parse(valtype, value)
-  end
+  stippleparse(eltype(targetfield), value)
 end
 
 """
@@ -606,11 +592,26 @@ end
 
 #===#
 
-function Base.parse(::Type{T}, value::Dict) where T <: AbstractDict
+# wrapper around Base.parse to prevent type piracy
+stippleparse(::Type{T}, value) where T = Base.parse(T, value)
+
+function stippleparse(::Type{T}, value::Dict) where T <: AbstractDict
   convert(T, value)
 end
 
-function Base.parse(::Type{T}, v::T) where {T}
+function stippleparse(::Type{<:AbstractFloat}, value::T) where T <: Integer
+  convert(valtype, value)
+end
+
+function stippleparse(::Type{T1}, value::T2) where {T1 <: AbstractArray, T2 <: AbstractArray}
+  convert(T1, value)
+end
+
+function stippleparse(::Type{T}, value) where T <: AbstractArray
+  convert(T, eltype(T)[value])
+end
+
+function stippleparse(::Type{T}, v::T) where {T}
   v::T
 end
 
@@ -644,7 +645,6 @@ function init(model::M, ui::Union{String,Vector} = ""; vue_app_name::String = St
     client = transport == Genie.WebChannels ? Genie.Requests.wsclient() : Genie.Requests.wtclient()
 
     # if only elements of the array change, oldval and newval are identical
-    @info payload
     ! isa(payload["newval"], Array) && ! isa(payload["newval"], Dict) && payload["newval"] == payload["oldval"] && return "OK"
 
     field = Symbol(payload["field"])


### PR DESCRIPTION
Proposal for a modified parsing approach as solution for #68 ;
construct a wrapper around `Base.parse()` to avaoid type piracy when defining fallbacks.

Background:
I had introduced `convertvalue(targetfield, value)` because I needed to be able to use both the value and the type of the targetfield for parsing OffsetArrays. So in most cases convertvalue was already a wrapper for Base.parse. But for the fallbacks I wrote an if-clause for the different types.

I think a cleaner approach would be to handle the different types by methods of an internal parser, which I now named stippleparse. It provides a general fallback to using `Base.parse()` to cover the existing methods and defines fallbacks for arrays and dicts.
In my post above I thought you meant that we switch to only using an internal parser instead of `Base.parse()` but apparently we misunderstood each other.

I hope that this PR makes clear what I had in mind and we can continue our discussion based on this piece of code.

As a MWE for using typed dicts:
```julia
Stipple.@kwdef mutable struct Example <: ReactiveModel
    d::R{Dict{String, String}} = Dict("a" => "b")
end

model = Stipple.init(Example())

ui() = page(vm(model), class="container", title="Hello Stipple", 
  ["test"]
)

route("/", ui)

up(open_browser=true)
```
open the browser tools and enter
```
Example.d.a = "hello"
```
at the console. Then return to your REPL and check the value of `model.d[]`.
In the existing Stipple version the value is not updated, with the PR it is.

If we follow this approach, we could also rename `stippleparse` to `Stipple.parse` or stippleconvert`. Let's discuss this if we have agreed on the approach.
