### PR TITLE
channel-dependent DEPS

### DIFF
--- a/src/Stipple.jl
+++ b/src/Stipple.jl
@@ -676,7 +676,7 @@ function init(model::M, ui::Union{String,Vector} = ""; vue_app_name::String = St
     end
   end
 
-  DEPS[@__MODULE__] = stipple_deps(model, vue_app_name, channel, debounce, core_theme, parse)
+  DEPS[channel] = stipple_deps(model, vue_app_name, channel, debounce, core_theme, parse)
 
   setup(model, channel)
 end
@@ -898,7 +898,7 @@ end
 #===#
 
 import OrderedCollections
-const DEPS = OrderedCollections.OrderedDict{Module, Function}()
+const DEPS = OrderedCollections.OrderedDict{Union{Module, String}, Function}()
 
 """
     `function deps_routes(channel::String = Genie.config.webchannels_default_route) :: Nothing`
@@ -956,7 +956,7 @@ function deps(channel::String = Genie.config.webchannels_default_route; core_the
     core_theme && Genie.Renderer.Html.script(src = Genie.Assets.asset_path(assets_config, :js, file="stipplecore"), defer= !Genie.Assets.external_assets(assets_config)),
     Genie.Renderer.Html.script(src = Genie.Assets.asset_path(assets_config, :js, file="vue_filters"), defer=true),
 
-    join([f() for f in collect(values(DEPS))], "\n")
+    join([f() for (key, f) in DEPS if isa(key, Module) || key == channel], "\n")
   )
 end
 


### PR DESCRIPTION
If multiple ReactiveModels are present on a site, `Stipple.init()` stores only the latest `stipple_deps()` in `DEPS[Stipple]`, although the deps are model and channel-dependent. So only the page with the model that was last initialised will work whereas the other receive the wrong deps.
I propose to make the DEPS channel-dependent by allowing also Strings as a key and to include all Module deps and the deps of the respective channel that is being rendered.
Alternatively one could introduce a new constant CHANNELDEPS ...