### PR TITLE
support push of single dict fields

### DIFF
--- a/assets/js/watchers.js
+++ b/assets/js/watchers.js
@@ -33,17 +33,48 @@ const watcherMixin = {
       }
     },
 
+    getindex: function (o, key) {
+      if (Array.isArray(o) & Array.isArray(key)) {
+        for (var i = 0, n = key.length; i < n; ++i) {
+          var k = key[i];
+          o = o[k]
+        }
+      } else {
+        if ((key in o) | Array.isArray(o)) {
+          o = o[key]
+        } else {
+          return
+        }
+      }
+      return o
+    },
+
+    setindex: function (o, val, key) {
+      if (Array.isArray(o) & Array.isArray(key)) {
+        for (var i = 0, n = key.length; i < n-1; ++i) {
+          var k = key[i];
+          o = o[k]
+        }
+        o[key[i]] = val
+      } else {
+        if ((key in o) | Array.isArray(o)) {
+          o[key] = val
+        } else {
+          return
+        }
+      }
+      return val
+    },
+    
     updateFieldAt: function (field, newVal, keys) {
       try {
         this.$withoutWatchers(() => {
           var o = this[field]
           for (var i = 0, n = keys.length; i < n-1; ++i) {
             var k = keys[i];
-            if (k in o) {
-                o = o[k];
-            }
+            o = this.getindex(o, k)
           }
-          o[keys[i]]=newVal
+          this.setindex(o, newVal, keys[i])
           this[field].__ob__.dep.notify()
         },"function(){return this." + field + "}");
       } catch(ex) {

--- a/assets/js/watchers.js
+++ b/assets/js/watchers.js
@@ -31,6 +31,24 @@ const watcherMixin = {
       } catch(ex) {
         console.log(ex);
       }
+    },
+
+    updateFieldAt: function (field, newVal, keys) {
+      try {
+        this.$withoutWatchers(() => {
+          var o = this[field]
+          for (var i = 0, n = keys.length; i < n-1; ++i) {
+            var k = keys[i];
+            if (k in o) {
+                o = o[k];
+            }
+          }
+          o[keys[i]]=newVal
+          this[field].__ob__.dep.notify()
+        },"function(){return this." + field + "}");
+      } catch(ex) {
+        console.log(ex);
+      }
     }
   }
 }

--- a/src/Elements.jl
+++ b/src/Elements.jl
@@ -75,8 +75,14 @@ function vue_integration(m::Type{M}; vue_app_name::String = "StippleApp", core_t
 
   window.parse_payload = function(payload){
     if (payload.key) {
-      window.$(vue_app_name).revive_payload(payload)
-      window.$(vue_app_name).updateField(payload.key, payload.value);
+      if (payload.revive) { 
+        window.$(vue_app_name).revive_payload(payload)
+      }
+      if (payload.mode=="dict") {
+        window.$(vue_app_name).updateFieldAt(payload.key, payload.value, payload.keys);
+      } else {
+        window.$(vue_app_name).updateField(payload.key, payload.value);
+      }
     }
   }
 

--- a/src/Stipple.jl
+++ b/src/Stipple.jl
@@ -892,16 +892,6 @@ function Base.push!(app::M, (k,v)::Pair{Symbol,T};
   end
 end
 
-# function Base.push!(app::M, (k,v))::Pair{Symbol,Reactive{T}};
-#                     options::Dict{Symbol, Any} = opts(),
-#                     channel::String = Genie.config.webchannels_default_route,
-#                     except::Union{Genie.WebChannels.HTTP.WebSockets.WebSocket,Nothing,UInt} = nothing,
-#                     mode::String = "normal",
-#                     keys::Vector{Symbol} = Symbol[]) where {T,M<:ReactiveModel}
-#   v = vals[2].r_mode != JSFUNCTION ? vals[2][] : replace_jsfunction(vals[2][])
-#   push!(app, Symbol(julia_to_vue(vals[1])) => v; channel, except, mode, keys)
-# end
-
 function Base.push!(model::M, fields::Vector{Symbol} = fieldnames(M);
                     channel::String = model.channel__,
                     skip::Vector{Symbol} = Symbol[]) where {M<:ReactiveModel}


### PR DESCRIPTION
This PR is the basis for pushing single fields of dictionaries and possibly array elements in the future.
I cleaned up the `push!(model::M)` methods for this purpose.
