### PR TITLE
refactoring of element-wise updates

### DIFF
--- a/src/Stipple.jl
+++ b/src/Stipple.jl
@@ -140,9 +140,10 @@ import Base.notify
 function Base.notify(observable::Observables.AbstractObservable, arg1, args...)
     val = observable[]
     for f in Observables.listeners(observable)
-        try
+        types = (typeof(val), typeof(arg1), typeof.(args)...)
+        if length(methods(f, types)) > 0
             Base.invokelatest(f, val, arg1, args...)
-        catch
+        else
             Base.invokelatest(f, val)
         end
     end


### PR DESCRIPTION
The current solution supplies the updated value and the vector of jskeys to the `notify()` routine.
This PR takes a more general approach and supplies a vector of pairs containing all objects (arrays or dicts) with their respective index. This makes it possible for users to write their own update functions that take into account, e.g. the index of the changed element.
Other changes:
- try-catch has been replaced by a proper `methods()` call to avoid decrease of performance.
- OffsetArrays are now handled correctly

This code could be transferred to Observables with only minor changes. I've commented [an open issue](https://github.com/JuliaGizmos/Observables.jl/issues/67) to ask if they are interested.

