### PR TITLE
Native event handlers

### DIFF
--- a/src/Elements.jl
+++ b/src/Elements.jl
@@ -295,9 +295,29 @@ Defines a js routine that is called by the given `action` of the Vue component, 
 julia> input("", @bind(:input), @on("keyup.enter", "process = true"))
 "<input  v-model='input' v-on:keyup.enter='process = true' />"
 ```
+
+If `expr` is a symbol, there must exist `Stipple.notify` override, i.e. an event
+handler function for a corresponding event with the name `expr`.
+
+### Example
+
+```julia
+julia> Stipple.notify(model, ::Val{:my_click}) = println("clicked")
+
+julia> @on("click", :my_click)
+"v-on:click='handle_event(\$event, 'my_click')'"
+```
 """
 macro on(args, expr)
-  :( "v-on:$(string($(esc(args))))='$(replace($(esc(expr)),"'" => raw"\'"))'" )
+  quote
+    e = string($(esc(args)))
+    x = $(esc(expr))
+    if typeof(x) <: Symbol
+        "v-on:$e='handle_event(\$event, \"$x\")'"
+    else
+        "v-on:$(string($(esc(args))))='$(replace(x,"'" => raw"\'"))'"
+    end
+  end
 end
 
 

--- a/src/Stipple.jl
+++ b/src/Stipple.jl
@@ -803,6 +803,18 @@ function init(m::Type{M};
     end
   end
 
+  ch = "/$channel/events"
+  if ! Genie.Router.ischannel(Symbol(ch))
+    Genie.Router.channel(ch, named = Symbol(ch)) do
+      # get event name
+      event = Genie.Requests.payload(:payload)["event"]
+      # form handler parameter & call event notifier
+      handler = Val(Symbol(get(event, "name", nothing)))
+      notify(model, handler)
+      return ok_response
+    end
+  end
+
   # ! haskey(DEPS, MODELDEPID) && (DEPS[MODELDEPID] = stipple_deps(m, vue_app_name, debounce, core_theme, endpoint, transport))
   haskey(DEPS, M) || (DEPS[M] = stipple_deps(m, vue_app_name, debounce, core_theme, endpoint, transport))
 

--- a/src/Stipple.jl
+++ b/src/Stipple.jl
@@ -387,6 +387,18 @@ function js_methods(app::T)::String where {T<:ReactiveModel}
   ""
 end
 
+function js_methods_events()::String
+"""
+  handle_event: function (event, handler) {
+    Genie.WebChannels.sendMessageTo(window.CHANNEL, 'events', {
+        'event': {
+            'name': handler
+        }
+    })
+  }
+"""
+end
+
 """
     function js_computed(app::T) where {T<:ReactiveModel}
 
@@ -976,11 +988,12 @@ function Stipple.render(app::M, fieldname::Union{Symbol,Nothing} = nothing)::Dic
               :data => merge(result, client_data(app)))
 
   isempty(components(app)   |> strip)   || push!(vue, :components => components(app))
-  isempty(js_methods(app)   |> strip)   || push!(vue, :methods    => JSONText("{ $(js_methods(app)) }"))
   isempty(js_computed(app)  |> strip)   || push!(vue, :computed   => JSONText("{ $(js_computed(app)) }"))
   isempty(js_watch(app)     |> strip)   || push!(vue, :watch      => JSONText("{ $(js_watch(app)) }"))
   isempty(js_created(app)   |> strip)   || push!(vue, :created    => JSONText("function(){ $(js_created(app)); }"))
   isempty(js_mounted(app)   |> strip)   || push!(vue, :mounted    => JSONText("function(){ $(js_mounted(app)); }"))
+  methods = js_methods(app) |> strip
+  push!(vue, :methods    => JSONText("{ $((isempty(methods) ? "" : methods*",")*js_methods_events()) }"))
 
   vue
 end


### PR DESCRIPTION
Currently events are only trigger a JavaScript code provided in `v-on:*` attribute. This PR prvides a simple callback mechanism for a Julia function associated with an `v-on:*` event using same web channel used for communicating changes between a model and a view.

The native event handlers defined as overrides of `Base.notify` with two parameters a model object and a value type which contains a name of the event, e.g. `notify(model::TestModel, ::Val{:button_click})`.

The following example shows a definition of an event handler function and its wiring with `@on` macro to a button. 

```julia
module JuliaEvents

using Revise
using Stipple, StippleUI

@reactive! mutable struct TestModel <: ReactiveModel
  counter::R{Int} = 0
end

# Event handler
function Base.notify(model::TestModel, ::Val{:button_click})
    @info "Button Click Event"
    model.counter[] += 1
end

function ui(model::TestModel)
    page(model, 
        row(class = "st-module", [
            cell([
                "Counter: "
                span("", @text(:counter))
            ]),
            cell([
                # wire 'click' event to the handler
                btn("Click me", @on(:click, :button_click)) 
            ])
        ])
    )
end

route("/") do
    init(TestModel) |> ui |> html
end

up(8000)

end 
```