### PR TITLE
Clearer error report in callwatchers

### DIFF
--- a/src/stipple/mutators.jl
+++ b/src/stipple/mutators.jl
@@ -34,7 +34,7 @@ function callwatchers(field, val, keys...; notify)
         Base.invokelatest(f, val)
       catch ex
         @error "Error attempting to invoke handler $count for field $field with value $val"
-        @error ex
+        @error "" exception=(ex, catch_backtrace())
         Genie.Configuration.isdev() && rethrow(ex)
       end
     end


### PR DESCRIPTION
add catch_backtrace() to display the backtrace in error log to help debugging