### PR TITLE
meta tags for default layout

### DIFF
--- a/src/ReactiveTools.jl
+++ b/src/ReactiveTools.jl
@@ -30,12 +30,14 @@ const REACTIVE_STORAGE = LittleDict{Module,LittleDict{Symbol,Expr}}()
 const HANDLERS = LittleDict{Module,Vector{Expr}}()
 const TYPES = LittleDict{Module,Union{<:DataType,Nothing}}()
 
-function DEFAULT_LAYOUT(; title::String = "Genie App")
+function DEFAULT_LAYOUT(; title::String = "Genie App", meta::Dict{<:AbstractString,<:AbstractString} = Dict("og:title" => "Genie App"))
+  tags = Genie.Renderers.Html.for_each(x -> """<meta name="$(x.first)" content="$(x.second)">\n    """, meta)
   """
 <!DOCTYPE html>
 <html>
   <head>
     <meta charset="utf-8">
+    $tags
     <% Stipple.sesstoken() %>
     <title>$title</title>
     <% if isfile(joinpath(Genie.config.server_document_root, "css", "genieapp.css")) %>


### PR DESCRIPTION
MWE for testing:
```julia
using Stipple.ReactiveTools: ReactiveTools.DEFAULT_LAYOUT, @page, @init
using Genie.Server: up
meta = Dict("og:title" => "test", "og:description" => "genie", "og:image" => "/here/it/is")
layout = DEFAULT_LAYOUT(meta=meta)
ui() = "hi"
@page("/", ui, layout)
up()
```
Result:
<img width="991" alt="image" src="https://user-images.githubusercontent.com/5058397/232601346-d8bf6741-aaad-4b5e-80b2-d510e21e4f12.png">

Will test on GC to see if social sharing works as expected.