### PR TITLE
Hh precompile

### DIFF
--- a/src/ReactiveTools.jl
+++ b/src/ReactiveTools.jl
@@ -271,7 +271,7 @@ end
 function binding(expr::Expr, m::Module, @nospecialize(mode::Any = nothing); source = nothing, reactive = true)
   (m == @__MODULE__) && return nothing
 
-  intmode = @eval Stipple $mode
+  intmode = mode isa Integer ? Int(mode) : @eval Stipple.$mode
   init_storage(m)
 
   var, field_expr = parse_expression!(expr, reactive ? mode : nothing, source, m)
@@ -285,7 +285,7 @@ function binding(expr::Expr, m::Module, @nospecialize(mode::Any = nothing); sour
 end
 
 function binding(expr::Expr, storage::LittleDict{Symbol, Expr}, @nospecialize(mode::Any = nothing); source = nothing, reactive = true, m::Module)
-  intmode = @eval Stipple $mode
+  intmode = mode isa Integer ? Int(mode) : @eval Stipple.$mode
 
   var, field_expr = parse_expression!(expr, reactive ? mode : nothing, source, m)
   storage[var] = field_expr

--- a/src/ReactiveTools.jl
+++ b/src/ReactiveTools.jl
@@ -118,8 +118,21 @@ end
 
 function Stipple.setmode!(expr::Expr, mode::Int, fieldnames::Symbol...)
   fieldname in [Stipple.CHANNELFIELDNAME, :modes__] && return
+  expr.args[2] isa Expr && expr.args[2].args[1] == :(Stipple._deepcopy) && (expr.args[2] = expr.args[2].args[2])
 
-  d = eval(expr.args[2])
+  d = if expr.args[2] isa LittleDict
+    copy(expr.args[2])
+  elseif expr.args[2] isa QuoteNode
+    expr.args[2].value
+  else # isa Expr generating a LittleDict (hopefully ...)
+    expr.args[2].args[1].args[1] == :(Stipple.LittleDict) || expr.args[2].args[1].args[1] == :(LittleDict) || error("Unexpected error while setting access properties of app variables")
+
+    d = LittleDict{Symbol, Int}()
+    for p in expr.args[2].args[2:end]
+      push!(d, p.args[2].value => p.args[3])
+    end
+    d
+  end
   for fieldname in fieldnames
     mode == PUBLIC ? delete!(d, fieldname) : d[fieldname] = mode
   end
@@ -416,7 +429,7 @@ macro init(modeltype)
     local initfn =  if isdefined($__module__, :init_from_storage)
                       $__module__.init_from_storage
                     else
-                      $__module__.init
+                      Stipple.init
                     end
     local handlersfn =  if isdefined($__module__, :__GF_AUTO_HANDLERS__)
                           if length(methods($__module__.__GF_AUTO_HANDLERS__)) == 0
@@ -439,7 +452,7 @@ end
 macro init()
   quote
     let type = Stipple.@type
-      @init(type)
+      Stipple.ReactiveTools.@init(type)
     end
   end |> esc
 end

--- a/src/Stipple.jl
+++ b/src/Stipple.jl
@@ -321,7 +321,7 @@ function init_storage()
   LittleDict{Symbol, Expr}(
     CHANNELFIELDNAME =>
       :($(Stipple.CHANNELFIELDNAME)::$(Stipple.ChannelName) = Stipple.channelfactory()),
-    :modes__ => :(modes__::Stipple.LittleDict{Symbol, Any} = Stipple.LittleDict{Symbol, Any}()),
+    :modes__ => :(modes__::Stipple.LittleDict{Symbol, Int} = Stipple.LittleDict{Symbol, Int}()),
     :isready => :(isready::Stipple.R{Bool} = false),
     :isprocessing => :(isprocessing::Stipple.R{Bool} = false)
   )

--- a/src/stipple/reactivity.jl
+++ b/src/stipple/reactivity.jl
@@ -176,8 +176,8 @@ function model_to_storage(::Type{T}, prefix = "", postfix = "") where T# <: Reac
 end
 
 function merge_storage(storage_1::AbstractDict, storage_2::AbstractDict; keep_channel = true)
-  m1 = eval(haskey(storage_1, :modes__) ? storage_1[:modes__].args[end] : LittleDict{Symbol, Any}())
-  m2 = eval(haskey(storage_2, :modes__) ? storage_2[:modes__].args[end] : LittleDict{Symbol, Any}())
+  m1 = eval(haskey(storage_1, :modes__) ? storage_1[:modes__].args[end] : LittleDict{Symbol, Int}())
+  m2 = eval(haskey(storage_2, :modes__) ? storage_2[:modes__].args[end] : LittleDict{Symbol, Int}())
   modes = merge(m1, m2)
   
   keep_channel && haskey(storage_2, :channel__) && (storage_2 = delete!(copy(storage_2), :channel__))
@@ -192,7 +192,7 @@ function merge_storage(storage_1::AbstractDict, storage_2::AbstractDict; keep_ch
     end
   end
   storage = merge(storage_1, storage_2)
-  storage[:modes__] = :(modes__::Stipple.LittleDict{Symbol, Any} = $modes)
+  storage[:modes__] = :(modes__::Stipple.LittleDict{Symbol, Int} = $modes)
 
   storage
 end

--- a/src/stipple/rendering.jl
+++ b/src/stipple/rendering.jl
@@ -67,7 +67,11 @@ end
 
 Default rendering of value types. Specialize `Stipple.render` to define custom rendering for your types.
 """
-function Stipple.render(val::T, fieldname::Union{Symbol,Nothing} = nothing) where {T}
+function Stipple.render(val::T, fieldname::Union{Symbol,Nothing}) where {T}
+  Stipple.render(val)
+end
+
+function Stipple.render(val::T) where {T}
   val
 end
 


### PR DESCRIPTION
This PR closes #194.
Further improvements:
- remove necessity to define Stipple.render methods with fieldname argument.
- type stability of the modes__ field
- support `import Stipple.ReactiveTools` instead of `using Stipple.ReactiveTools`