### PR TITLE
Add extensions for OffsetArrays and DataFrames

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -21,6 +21,15 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 StructTypes = "856f2bd8-1eba-4b0a-8007-ebc267875bd4"
+Tables  = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
+
+[weakdeps]
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
+
+[extensions]
+StippleDataFramesExt = "DataFrames"
+StippleOffsetArraysExt = "OffsetArrays"
 
 [compat]
 FilePathsBase = "0.9"
@@ -37,9 +46,14 @@ Reexport = "1"
 Requires = "1"
 StructTypes = "1.8"
 julia = "1.6"
+OffsetArrays = "1"
+DataFrames = "1"
+Tables = "1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 
 [targets]
-test = ["Test"]
+test = ["Test", "DataFrames", "OffsetArrays"]

--- a/ext/StippleDataFrames.jl
+++ b/ext/StippleDataFrames.jl
@@ -1,0 +1,7 @@
+function Stipple.stipple_parse(::Type{DF} where DF <: DataFrames.AbstractDataFrame, d::Vector)
+  isempty(d) ? DF() : reduce(vcat, DataFrames.DataFrame.(d))
+end
+
+function Stipple.render(df::DataFrames.DataFrame)
+  OrderedDict(zip(names(df), eachcol(df)))
+end

--- a/ext/StippleDataFramesExt.jl
+++ b/ext/StippleDataFramesExt.jl
@@ -1,0 +1,16 @@
+module StippleDataFramesExt
+
+@static if isdefined(Base, :get_extension)
+  using Stipple
+  using DataFrames
+end
+
+function Stipple.stipple_parse(::Type{DF} where DF <: DataFrames.AbstractDataFrame, d::Vector)
+  isempty(d) ? DF() : reduce(vcat, DataFrames.DataFrame.(d))
+end
+
+function Stipple.render(df::DataFrames.DataFrame)
+  OrderedDict(zip(names(df), eachcol(df)))
+end
+  
+end

--- a/ext/StippleOffsetArrays.jl
+++ b/ext/StippleOffsetArrays.jl
@@ -1,0 +1,12 @@
+function Stipple.convertvalue(targetfield::Union{Ref{T}, Reactive{T}}, value) where T <: OffsetArrays.OffsetArray
+  a = Stipple.stipple_parse(eltype(targetfield), value)
+
+  # if value is not an OffsetArray use the offset of the current array
+  if ! isa(value, OffsetArrays.OffsetArray)
+    o = targetfield[].offsets
+    OffsetArrays.OffsetArray(a, OffsetArrays.Origin(1 .+ o))
+  # otherwise use the existing value
+  else
+    a
+  end
+end

--- a/ext/StippleOffsetArraysExt.jl
+++ b/ext/StippleOffsetArraysExt.jl
@@ -1,0 +1,19 @@
+module StippleOffsetArraysExt
+
+using Stipple
+using OffsetArrays
+
+function Stipple.convertvalue(targetfield::Union{Ref{T}, Reactive{T}}, value) where T <: OffsetArrays.OffsetArray
+  a = Stipple.stipple_parse(eltype(targetfield), value)
+
+  # if value is not an OffsetArray use the offset of the current array
+  if ! isa(value, OffsetArrays.OffsetArray)
+    o = targetfield[].offsets
+    OffsetArrays.OffsetArray(a, OffsetArrays.Origin(1 .+ o))
+  # otherwise use the existing value
+  else
+    a
+  end
+end
+
+end

--- a/ext/StippleTablesExt.jl
+++ b/ext/StippleTablesExt.jl
@@ -1,0 +1,7 @@
+module StippleTablesExt
+
+using Stipple
+import Tables
+
+
+end

--- a/src/stipple/rendering.jl
+++ b/src/stipple/rendering.jl
@@ -140,7 +140,11 @@ function Stipple.render(val::T, fieldname::Union{Symbol,Nothing}) where {T}
 end
 
 function Stipple.render(val::T) where {T}
-  val
+  Tables.istable(val) ? rendertable(val) : val
+end
+
+function Stipple.rendertable(@nospecialize table)
+  OrderedDict(zip(Tables.columnnames(table), Tables.columns(table)))
 end
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -132,3 +132,15 @@ end
     @eval model = @init
     @eval @test propertynames(model) == (:channel__, :modes__, :isready, :isprocessing, :i3, :s3, :j, :t, :mixin_j, :mixin_t, :pre_j_post, :pre_t_post)
 end
+
+using DataFrames
+@testset "Extensions" begin
+    d = Dict(:a => [1, 2, 3], :b => ["a", "b", "c"])
+    df = DataFrame(:a => [1, 2, 3], :b => ["a", "b", "c"])
+    
+    @test Stipple.stipple_parse(DataFrame, [d]) == df
+    @test render(df) == OrderedDict("a" => [1, 2, 3], "b" => ["a", "b", "c"])
+
+    using OffsetArrays
+    @test Stipple.convertvalue(R(OffsetArray([1, 2, 3], -2)), [2, 3, 4]) == OffsetArray([2, 3, 4], -2)
+end


### PR DESCRIPTION
This PR accounts for the new extension architecture in Julia 1.9, which replaces Requires.jl

Due to errors in using Revise together with Requires in Julia 1.8.5 I have added two different extension files for 1.9 and pre-1.9:

1.9:
- StippleOffsetArraysExt.jl
- StippleDataFramesExt.jl

pre-1.9 (no modules):
- StippleOffsetArraysjl
- StippleDataFrames.jl