### PR TITLE
support kwargs in `@page` macro

### DIFF
--- a/src/Pages.jl
+++ b/src/Pages.jl
@@ -32,6 +32,9 @@ function Page(  route::Union{Route,String};
                 model::Union{M,Function,Nothing,Expr,Module} = Stipple.init(EmptyModel),
                 layout::Union{Genie.Renderers.FilePath,<:AbstractString,ParsedHTMLString,Nothing,Function} = nothing,
                 context::Module = @__MODULE__,
+                debounce::Int = Stipple.JS_DEBOUNCE_TIME,
+                transport::Module = Genie.WebChannels,
+                core_theme::Bool = true,
                 kwargs...
               ) where {M<:ReactiveModel}
 
@@ -39,7 +42,7 @@ function Page(  route::Union{Route,String};
             Core.eval(context, model)
           elseif isa(model, Module)
             context = model
-            @eval(context, @init())
+            @eval(context, @init(debounce = debounce, transport = transport, core_theme = core_theme))
           else
             model
           end

--- a/src/Pages.jl
+++ b/src/Pages.jl
@@ -29,7 +29,7 @@ pages() = _pages
 
 function Page(  route::Union{Route,String};
                 view::Union{Genie.Renderers.FilePath,<:AbstractString,ParsedHTMLString,Vector{<:AbstractString},Function},
-                model::Union{M,Function,Nothing,Expr,Module} = Stipple.init(EmptyModel),
+                model::Union{M,Function,Nothing,Expr,Module,Type{M}} = Stipple.init(EmptyModel),
                 layout::Union{Genie.Renderers.FilePath,<:AbstractString,ParsedHTMLString,Nothing,Function} = nothing,
                 context::Module = @__MODULE__,
                 debounce::Int = Stipple.JS_DEBOUNCE_TIME,
@@ -42,7 +42,9 @@ function Page(  route::Union{Route,String};
             Core.eval(context, model)
           elseif isa(model, Module)
             context = model
-            @eval(context, @init(debounce = debounce, transport = transport, core_theme = core_theme))
+            @eval(context, Stipple.ReactiveTools.@init(debounce = $debounce, transport = $transport, core_theme = $core_theme))
+          elseif model isa DataType
+            @eval(context, Stipple.ReactiveTools.@init($model; debounce = $debounce, transport = $transport, core_theme = $core_theme))
           else
             model
           end

--- a/src/ReactiveTools.jl
+++ b/src/ReactiveTools.jl
@@ -17,7 +17,7 @@ export @onchange, @onbutton, @event, @notify
 export @clear, @clear_vars, @clear_handlers
 
 # app handling
-export @page, @init, @handlers, @app, @appname
+export @page, @init, @handlers, @app, @appname, @modelstorage
 
 # js functions on the front-end (see Vue.js docs)
 export @methods, @watch, @computed, @client_data, @add_client_data
@@ -591,7 +591,7 @@ macro init(args...)
                         else
                           identity
                         end
-                        
+    
     instance = let model = initfn($(init_args...))
       new_handlers ? Base.invokelatest(handlersfn, model) : handlersfn(model)
     end
@@ -997,7 +997,7 @@ macro page(expressions...)
             :model => () -> @eval(__module__, @init())
         )
     )
-@show args
+
     :(Stipple.Pages.Page($(args...), $url, view = $view)) |> esc
 end
 
@@ -1254,6 +1254,12 @@ macro notify(args...)
 
   quote
     Base.notify(__model__, $(args...))
+  end |> esc
+end
+
+macro modelstorage()
+  quote
+    using Stipple.ModelStorage.Sessions
   end |> esc
 end
 

--- a/src/ReactiveTools.jl
+++ b/src/ReactiveTools.jl
@@ -252,6 +252,11 @@ macro type()
   esc(:($type))
 end
 
+import Stipple.@clear_cache
+macro clear_cache()
+  :(Stipple.clear_cache(Stipple.@type)) |> esc
+end
+
 function update_storage(m::Module)
   clear_type(m)
   # isempty(Stipple.Pages._pages) && return

--- a/src/ReactiveTools.jl
+++ b/src/ReactiveTools.jl
@@ -257,6 +257,11 @@ macro clear_cache()
   :(Stipple.clear_cache(Stipple.@type)) |> esc
 end
 
+import Stipple.@clear_route
+macro clear_route()
+  :(Stipple.clear_route(Stipple.@type)) |> esc
+end
+
 function update_storage(m::Module)
   clear_type(m)
   # isempty(Stipple.Pages._pages) && return
@@ -581,8 +586,8 @@ macro init(args...)
                           identity
                         end
                         
-    let model = initfn($(init_args...))
-      instance = new_handlers ? Base.invokelatest(handlersfn, model) : handlersfn(model)
+    instance = let model = initfn($(init_args...))
+      new_handlers ? Base.invokelatest(handlersfn, model) : handlersfn(model)
     end
     for p in Stipple.Pages._pages
       p.context == $__module__ && (p.model = instance)

--- a/src/ReactiveTools.jl
+++ b/src/ReactiveTools.jl
@@ -882,7 +882,7 @@ macro onchange(location, vars, expr)
   known_reactive_vars, known_non_reactive_vars = get_known_vars(loc)
   known_vars = vcat(known_reactive_vars, known_non_reactive_vars)
   on_vars = fieldnames_to_fields(vars, known_vars)
-
+  
   expr, used_vars = mask(expr, known_vars)
   do_vars = Symbol[]
 
@@ -960,7 +960,7 @@ macro onbutton(location, var, expr)
   var = fieldnames_to_fields(var, known_vars)
 
   expr = fieldnames_to_fields(expr, known_non_reactive_vars)
-  expr = fieldnames_to_fieldcontent(expr, known_reactive_vars)
+  expr = fieldnames_to_fieldcontent(expr, known_reactive_vars, known_reactive_vars)
   expr = unmask(expr, known_vars)
 
   ex = :(onbutton($var) do

--- a/src/Stipple.jl
+++ b/src/Stipple.jl
@@ -191,6 +191,7 @@ function setmode! end
 function deletemode! end
 function init_storage end
 
+include("Tools.jl")
 include("ReactiveTools.jl")
 
 #===#

--- a/src/Tools.jl
+++ b/src/Tools.jl
@@ -33,7 +33,7 @@ function expressions_to_args(@nospecialize(expressions); args_to_kwargs::Vector{
         if ex isa Expr && ex.head == :(=)
             ex.head = :kw
             push!(keys, ex.args[1])
-        elseif ex.head != :parameters
+        elseif !isa(ex, Expr) || ex.head != :parameters
             push!(inds, i)
         end
     end

--- a/src/Tools.jl
+++ b/src/Tools.jl
@@ -1,0 +1,58 @@
+"""
+    expressions_to_args(@nospecialize(expressions); args_to_kwargs::Vector{Symbol} = [], defaults::AbstractDict{Symbol} = Dict())
+
+Convert macro arguments (expressions) to arguments that can be passed to a function, including keyword arguments
+    - kwargs are automatically converted
+    - positional args can be converted to kwargs in a given order (`args_to_kwargs`)
+    - default values for expected kwargs can be defined `defaults`
+
+Example
+```
+f(args...; kwargs...) = [args, Dict(kwargs)]
+
+macro f(expressions...)
+    args = expressions_to_args(expressions)
+    :(f(\$(args...))) |> esc
+end
+
+@f(1, [2, 3], a = 4, "567")
+# 2-element Vector{Any}:
+#  (1, [2, 3], "567")
+#  Dict(:a => 4)
+```
+"""
+function expressions_to_args(@nospecialize(expressions); args_to_kwargs::Vector{Symbol} = Symbol[], defaults::AbstractDict{Symbol} = Dict{Symbol, Any}())
+    keys = Symbol[]
+    inds = Int[]
+
+    expressions isa Tuple && (expressions = Any[expressions...])
+    # convert assignment expressions to keyword argument expressions
+    # and collect the indices of positional arguments
+    for (i, ex) in enumerate(expressions)
+        if ex isa Expr && ex.head == :(=)
+            ex.head = :kw
+            push!(keys, ex.args[1])
+        else
+            push!(inds, i)
+        end
+    end
+
+    # collect positional args and convert them to kwargs according to the symbols in 'args_to_kwargs'
+    # if they are not contained in the list of kwargs already and delete them from the list of positional args
+    for (i, kwarg) in zip(inds, args_to_kwargs)
+        if kwarg ∉ keys
+            push!(expressions, :($(Expr(:kw, kwarg, expressions[i]))))
+            push!(keys, kwarg)
+        end
+    end
+    deleteat!(expressions, inds[1:min(length(args_to_kwargs), length(inds))])
+
+    # apply default values for kwargs if there are any
+    for kwarg in Base.keys(defaults)
+        if kwarg ∉ keys
+            push!(expressions, :($(Expr(:kw, kwarg, defaults[kwarg]))))
+        end
+    end
+
+    return expressions
+end

--- a/src/stipple/reactivity.jl
+++ b/src/stipple/reactivity.jl
@@ -122,7 +122,7 @@ end
 """
 abstract type ReactiveModel end
 
-export @vars, @add_vars, @define_mixin, @clear_cache, clear_cache
+export @vars, @add_vars, @define_mixin, @clear_cache, clear_cache, @clear_route, clear_route
 
 # deprecated
 export @reactive, @reactive!, @old_reactive, @old_reactive!

--- a/src/stipple/reactivity.jl
+++ b/src/stipple/reactivity.jl
@@ -339,9 +339,20 @@ macro var_storage(expr, new_inputmode = :auto)
     esc(:($storage))
 end
 
+Stipple.Genie.Router.delete!(M::Type{<:ReactiveModel}) = Stipple.Genie.Router.delete!(Symbol(Stipple.routename(M)))
+
+function clear_route(M::Type{<:ReactiveModel})
+  Stipple.Genie.Router.delete!(M)
+  return nothing
+end
+
+macro clear_route(App)
+  :(Stipple.clear_route($(esc(App))))
+end
+
 function clear_cache(M::Type{<:ReactiveModel})
   delete!.(Ref(Stipple.DEPS), filter(x -> x isa Type && x <: M, keys(Stipple.DEPS)))
-  Stipple.Genie.Router.delete!(Symbol(Stipple.routename(M)))
+  Stipple.Genie.Router.delete!(M)
   return nothing
 end
 

--- a/src/stipple/reactivity.jl
+++ b/src/stipple/reactivity.jl
@@ -122,7 +122,7 @@ end
 """
 abstract type ReactiveModel end
 
-export @vars, @add_vars, @define_mixin
+export @vars, @add_vars, @define_mixin, @clear_cache, clear_cache
 
 # deprecated
 export @reactive, @reactive!, @old_reactive, @old_reactive!
@@ -337,6 +337,16 @@ macro var_storage(expr, new_inputmode = :auto)
     end
 
     esc(:($storage))
+end
+
+function clear_cache(M::Type{<:ReactiveModel})
+  delete!.(Ref(Stipple.DEPS), filter(x -> x isa Type && x <: M, keys(Stipple.DEPS)))
+  Stipple.Genie.Router.delete!(Symbol(Stipple.routename(M)))
+  return nothing
+end
+
+macro clear_cache(App)
+  :(Stipple.clear_cache($(esc(App))))
 end
 
 macro type(modelname, storage)

--- a/src/stipple/rendering.jl
+++ b/src/stipple/rendering.jl
@@ -39,7 +39,7 @@ function join_js(xx, delim = ""; skip_empty = true, pre::Function = identity, st
   for x_raw in xx
     x = x_raw isa Base.Callable ? x_raw() : x_raw
     io2 = IOBuffer()
-    if x isa Union{AbstractDict, Pair, Base.Pairs, Vector{<:Pair}}
+    if x isa Union{AbstractDict, Pair, Base.Iterators.Pairs, Vector{<:Pair}}
       s = json(Dict(k => JSONText(v) for (k, v) in (x isa Pair ? [x] : x)))[2:end - 1]
       print(io2, s)
     else

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -209,7 +209,11 @@ end
     
         ui() = "DEMO UI"
         debounce = 10
+    end
 
+    @eval model = @init
+    
+    @eval begin
         @page("/", ui)
         @page("/nolayout", ui, layout = "no layout")
         @page("/debounce", ui, debounce = 50)
@@ -261,9 +265,10 @@ end
     
         ui() = "DEMO UI explicit"
         debounce = 11
-        # @eval model = @init(MyApp)
     end
     
+    @eval model = @init(MyApp)
+
     @eval begin
         @page("/", ui; model = MyApp)
         @page("/nolayout", ui, layout = "no layout (explicit)", model = MyApp)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,20 @@
 using Stipple
+using Stipple.Genie.HTTPUtils.HTTP
+
 using Test
+
+function string_get(x)
+    String(HTTP.get(x, retries = 0, status_exception = false).body)
+end
+
+function get_channel(s::String)
+    match(r"window.CHANNEL = '([^']+)'", s).captures[1]
+end
+
+function get_debounce(port, modelname)
+    s = string_get("http://localhost:$port/stipple.jl/master/assets/js/$modelname.js")
+    parse(Int, match(r"_.debounce\(.+?(\d+)\)", s).captures[1])
+end
 
 @vars TestMixin begin
     j = 101
@@ -81,18 +96,26 @@ using Stipple.ReactiveTools
     @test model.s[] == "20"
 end
 
-@testset "Reactive API (explicit) with mixins" begin
-    @app TestApp begin
+@testset "Reactive API (explicit) with mixins and handlers" begin
+    @eval @app TestApp begin
         @in i = 100
         @out s = "Hello"
     
         @mixin TestMixin
         @mixin mixin_::TestMixin
         @mixin TestMixin "pre_" "_post"
+
+        @onchange i begin
+            s = "$i"
+        end
     end
 
-    model = TestApp |> init |> handlers
+    @eval model = TestApp |> init |> handlers
     @test propertynames(model) == (:channel__, :modes__, :isready, :isprocessing, :i, :s, :j, :t, :mixin_j, :mixin_t, :pre_j_post, :pre_t_post)
+        
+    # check reactivity
+    @eval model.i[] = 20
+    @test model.s[] == "20"
 end
 
 @testset "Reactive API (implicit)" begin
@@ -119,7 +142,7 @@ end
     @test model.s2[] == "20"
 end
 
-@testset "Reactive API (implicit) with mixins" begin
+@testset "Reactive API (implicit) with mixins and handlers" begin
     @eval @app begin
         @in i3 = 100
         @out s3 = "Hello"
@@ -127,10 +150,17 @@ end
         @mixin TestMixin
         @mixin mixin_::TestMixin
         @mixin TestMixin "pre_" "_post"
+
+        @onchange i3 begin
+            s3 = "$i3"
+        end
     end
 
     @eval model = @init
     @eval @test propertynames(model) == (:channel__, :modes__, :isready, :isprocessing, :i3, :s3, :j, :t, :mixin_j, :mixin_t, :pre_j_post, :pre_t_post)
+
+    @eval model.i3[] = 20
+    @test model.s3[] == "20"
 end
 
 using DataFrames
@@ -162,4 +192,114 @@ end
     
     mt = Tables.table([1 2; 3 4])
     @test render(mt) == OrderedDict(:Column1 => [1, 3], :Column2 => [2, 4])
+end
+
+# Basic server tests (should be enhanced over time perhaps...)
+
+@testset "Serving implicit app" begin
+    @eval begin
+        @app begin
+            @in i3 = 100
+            @out s3 = "Hello"
+
+            @onchange i3 begin
+                s3 = "$i3"
+            end
+        end
+    
+        ui() = "DEMO UI"
+        debounce = 10
+
+        @page("/", ui)
+        @page("/nolayout", ui, layout = "no layout")
+        @page("/debounce", ui, debounce = 50)
+        @page("/debounce2", ui; debounce)
+        @page("/static", ui; model)
+    end
+    
+    port = rand(8001:9000)
+    up(;port, ws_port = port)
+
+    @test occursin("<p>DEMO UI</p>", string_get("http://localhost:$port"))
+
+    @test string_get("http://localhost:$port/nolayout") == "<!DOCTYPE html><html>\n  <body>\n    <p>no layout</p>\n  </body></html>"
+    
+    @test get_debounce(port, "main_reactivemodel") == 300
+    
+    @clear_cache
+    # first get the main page to trigger init function, which sets up the assets
+    string_get("http://localhost:$port/debounce")
+    @test get_debounce(port, "main_reactivemodel") == 50
+
+    @clear_cache
+    string_get("http://localhost:$port/debounce2")
+    @test get_debounce(port, "main_reactivemodel") == 10
+
+    s1 = string_get("http://localhost:$port/")
+    s2 = string_get("http://localhost:$port/")
+
+    s3 = string_get("http://localhost:$port/static")
+    s4 = string_get("http://localhost:$port/static")
+
+    @test get_channel(s2) != get_channel(s1)
+    @test get_channel(s3) == get_channel(s4)
+
+    @clear_cache
+    down()
+end
+
+@testset "Serving explicit app" begin
+    @eval begin
+        @app MyApp begin
+            @in i3 = 100
+            @out s3 = "Hello"
+    
+            @onchange i3 begin
+                s3 = "$i3"
+            end
+        end
+    
+        ui() = "DEMO UI explicit"
+        debounce = 11
+        # @eval model = @init(MyApp)
+    end
+    
+    @eval begin
+        @page("/", ui; model = MyApp)
+        @page("/nolayout", ui, layout = "no layout (explicit)", model = MyApp)
+        @page("/debounce", ui, debounce = 51; model = MyApp)
+        @page("/debounce2", ui; debounce, model = MyApp)
+        @page("/static1", ui; model)
+    end
+    
+    port = rand(8001:9000)
+    up(;port, ws_port = port)
+    
+    @clear_cache MyApp
+    @test occursin("<p>DEMO UI explicit</p>", string_get("http://localhost:$port"))
+    
+    @test string_get("http://localhost:$port/nolayout") == "<!DOCTYPE html><html>\n  <body>\n    <p>no layout (explicit)</p>\n  </body></html>"
+    
+    @test get_debounce(port, "myapp") == 300
+    
+    @clear_cache MyApp
+    # first get the main page to trigger init function, which sets up the assets
+    string_get("http://localhost:$port/debounce")
+    @test get_debounce(port, "myapp") == 51
+    
+    @clear_cache MyApp
+    string_get("http://localhost:$port/debounce2")
+    @test get_debounce(port, "myapp") == 11
+    
+    s1 = string_get("http://localhost:$port/")
+    s2 = string_get("http://localhost:$port/")
+
+    s3 = string_get("http://localhost:$port/static1")
+    s4 = string_get("http://localhost:$port/static1")
+
+    @test get_channel(s2) != get_channel(s1)
+    @test get_channel(s3) == get_channel(s4)
+    
+    @clear_cache MyApp
+    down()
 end


### PR DESCRIPTION
Currently different methods of the `@page` macro are distinguishable only by the number of arguments, requiring the argument order `url`, `view`, `layout`, `model`, `context`.
With the new macro tool `expressions_to_args()` we can support a kwarg-like macro call, e.g.
```
model = @init
@page("/", ui, model = model)
```
for global models without the requirement to specify a layout.

EDIT: Note that the `;`-Syntax with auto duplication for kwargs is not supported in macros