### PR TITLE
interoperability for Stipple.JSONText and JSON.JSONText

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -21,39 +21,43 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 StructTypes = "856f2bd8-1eba-4b0a-8007-ebc267875bd4"
-Tables  = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
+Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [weakdeps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 
 [extensions]
 StippleDataFramesExt = "DataFrames"
 StippleOffsetArraysExt = "OffsetArrays"
+StippleJSONExt = "JSON"
 
 [compat]
+DataFrames = "1"
 FilePathsBase = "0.9"
 Genie = "5.18"
 GenieSession = "1"
 GenieSessionFileSession = "1"
 JSON3 = "1.9"
+JSON = "0.20, 0.21"
 MacroTools = "0.5"
 Mixers = "0.1.2"
 Observables = "0.3, 0.4, 0.5"
+OffsetArrays = "1"
 OrderedCollections = "1"
 Parameters = "0.12"
 Reexport = "1"
 Requires = "1"
 StructTypes = "1.8"
-julia = "1.6"
-OffsetArrays = "1"
-DataFrames = "1"
 Tables = "1"
+julia = "1.6"
 
 [extras]
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "DataFrames", "OffsetArrays"]
+test = ["Test", "DataFrames", "JSON", "OffsetArrays"]

--- a/ext/StippleJSON.jl
+++ b/ext/StippleJSON.jl
@@ -1,0 +1,10 @@
+# garantee interoperability of different JSONTText definitions of JSON3 and JSON
+
+JSON.JSONText(json::Stipple.JSONText) = JSON.JSONText(json.s)
+JSON.show_json(io::JSON.Writer.CompactContext, s::JSON.Writer.CS, json::Stipple.JSONText) = write(io, json.s)
+JSON.Writer.lower(json::Stipple.JSONText) = JSON.parse(json.s)
+
+Stipple.JSONText(json::JSON.JSONText) = Stipple.JSONText(json.s)
+@inline StructTypes.StructType(::Type{JSON.JSONText}) = JSON3.RawType()
+@inline StructTypes.construct(::Type{JSON.JSONText}, json::JSON3.RawValue) = JSONText(string(json))
+@inline JSON3.rawbytes(json::JSON.JSONText) = codeunits(json.s)

--- a/ext/StippleJSON.jl
+++ b/ext/StippleJSON.jl
@@ -2,7 +2,7 @@
 
 JSON.JSONText(json::Stipple.JSONText) = JSON.JSONText(json.s)
 JSON.show_json(io::JSON.Writer.CompactContext, s::JSON.Writer.CS, json::Stipple.JSONText) = write(io, json.s)
-JSON.Writer.lower(json::Stipple.JSONText) = JSON.parse(json.s)
+JSON.Writer.lower(json::Stipple.JSONText) = json.s
 
 Stipple.JSONText(json::JSON.JSONText) = Stipple.JSONText(json.s)
 @inline StructTypes.StructType(::Type{JSON.JSONText}) = JSON3.RawType()

--- a/ext/StippleJSONExt.jl
+++ b/ext/StippleJSONExt.jl
@@ -1,0 +1,18 @@
+module StippleJSONExt
+
+using Stipple
+using JSON
+
+# garantee interoperability of different JSONTText definitions in Stipple and JSON
+# for both JSON3 and JSON
+
+JSON.JSONText(json::Stipple.JSONText) = JSON.JSONText(json.s)
+JSON.show_json(io::JSON.Writer.CompactContext, s::JSON.Writer.CS, json::Stipple.JSONText) = write(io, json.s)
+JSON.Writer.lower(json::Stipple.JSONText) = JSON.parse(json.s)
+
+Stipple.JSONText(json::JSON.JSONText) = Stipple.JSONText(json.s)
+@inline StructTypes.StructType(::Type{JSON.JSONText}) = JSON3.RawType()
+@inline StructTypes.construct(::Type{JSON.JSONText}, json::JSON3.RawValue) = JSONText(string(json))
+@inline JSON3.rawbytes(json::JSON.JSONText) = codeunits(json.s)
+
+end

--- a/ext/StippleJSONExt.jl
+++ b/ext/StippleJSONExt.jl
@@ -5,10 +5,12 @@ using JSON
 
 # garantee interoperability of different JSONTText definitions in Stipple and JSON
 # for both JSON3 and JSON
+# Note that `lower` for Stipple.JSONText is not defined as parse(json.s), because that would require
+# pure proper JSON. For transmissions of bindings, though, we need to allow to pass object names.
 
 JSON.JSONText(json::Stipple.JSONText) = JSON.JSONText(json.s)
 JSON.show_json(io::JSON.Writer.CompactContext, s::JSON.Writer.CS, json::Stipple.JSONText) = write(io, json.s)
-JSON.Writer.lower(json::Stipple.JSONText) = JSON.parse(json.s)
+JSON.Writer.lower(json::Stipple.JSONText) = json.s
 
 Stipple.JSONText(json::JSON.JSONText) = Stipple.JSONText(json.s)
 @inline StructTypes.StructType(::Type{JSON.JSONText}) = JSON3.RawType()

--- a/src/Stipple.jl
+++ b/src/Stipple.jl
@@ -15,6 +15,8 @@ existing Vue.js libraries.
 """
 module Stipple
 
+const PRECOMPILE = Ref(false)
+
 """
 @using_except(expr)
 
@@ -214,6 +216,12 @@ function __init__()
     @require DataFrames  = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0" begin
       # evaluate the code of the extension without the surrounding module
       include(joinpath(@__DIR__, "..", "ext", "StippleDataFrames.jl"))
+      # Core.eval(@__MODULE__, Meta.parse(join(jl, ';')).args[3])
+    end
+
+    @require JSON  = "682c06a0-de6a-54ab-a142-c8b1cf79cde6" begin
+      # evaluate the code of the extension without the surrounding module
+      include(joinpath(@__DIR__, "..", "ext", "StippleJSON.jl"))
       # Core.eval(@__MODULE__, Meta.parse(join(jl, ';')).args[3])
     end
   end
@@ -443,7 +451,7 @@ function init(::Type{M};
   # add a timer that checks if the model is outdated and if so prepare the model to be garbage collected
   LAST_ACTIVITY[Symbol(getchannel(model))] = now()
 
-  Timer(setup_purge_checker(model), PURGE_CHECK_DELAY[], interval = PURGE_CHECK_DELAY[])
+  PRECOMPILE[] || Timer(setup_purge_checker(model), PURGE_CHECK_DELAY[], interval = PURGE_CHECK_DELAY[])
 
   if is_channels_webtransport()
     Genie.Assets.channels_subscribe(channel)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -351,3 +351,14 @@ end
 
     @test cell(col = -1, sm = 9) == "<div class=\"st-col col-sm-9\"></div>"
 end
+
+@testset "Compatibility of JSONText between JSON3 and JSON" begin
+    using JSON
+    using Stipple
+    jt1 = JSON.JSONText("json text 1")
+    jt2 = Stipple.JSONText("json text 2")
+    @test JSON.json(jt1) == "json text 1"
+    @test Stipple.json(jt1) == "json text 1"
+    @test JSON.json(jt2) == "json text 2"
+    @test Stipple.json(jt2) == "json text 2"
+end


### PR DESCRIPTION
Only after [fixing handling of Stipple.JSONText in StipplePlotly](https://github.com/GenieFramework/StipplePlotly.jl/commit/54f15062fc81d6385753aceea300be5478d1fc21) I understood the root cause of the error.

It is that Stipple's definition of `JSONText` for JSON3 doesn't interoperate with JSON's definition, but PlotlyBase's JSON3-rendering is calling JSON behind the scenes. Therefore, `Stipple.JSONText("test")` is rendered as `"{\"s\": \"test\"}`
```julia
julia> JSON.json(Stipple.JSONText("test"))
"{\"s\":\"test\"}"
```
This PR adds all necessary methods to JSON3 and JSON to grant interoperability of the JSONText definitions so that
```julia
julia> JSON.json(Stipple.JSONText("test"))
"test"
```
Respective tests are added to `runtests.jl`
So if in future some component adds JSON3 rendering via a JSON fallback, we are save to use our `Stipple.JSONText`.