### PR TITLE
add js_attr(x) for setting julia expressions as js attributes, fix JSONText in Plots

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Stipple"
 uuid = "4acbeb90-81a0-11ea-1966-bdaff8155998"
 authors = ["Adrian <e@essenciary.com>"]
-version = "0.27.11"
+version = "0.27.12"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/ext/StippleJSONExt.jl
+++ b/ext/StippleJSONExt.jl
@@ -11,7 +11,7 @@ isdefined(Base, :get_extension) ? using JSON : using ..JSON
 
 JSON.JSONText(json::Stipple.JSONText) = JSON.JSONText(json.s)
 JSON.show_json(io::JSON.Writer.CompactContext, ::JSON.Writer.CS, json::Stipple.JSONText) = write(io, json.s)
-JSON.Writer.lower(json::Stipple.JSONText) = json.s
+JSON.Writer.lower(json::Stipple.JSONText) = json
 
 Stipple.JSONText(json::JSON.JSONText) = Stipple.JSONText(json.s)
 @inline StructTypes.StructType(::Type{JSON.JSONText}) = JSON3.RawType()

--- a/src/Stipple.jl
+++ b/src/Stipple.jl
@@ -76,7 +76,7 @@ using Logging, Mixers, Random, Reexport, Dates, Tables
 import Genie.Router.download
 @reexport @using_except Genie.Renderer.Html: mark, div, time, view, render, Headers
 const htmldiv = Html.div
-export render, htmldiv
+export render, htmldiv, js_attr
 @reexport using JSON3
 @reexport using StructTypes
 @reexport using Parameters

--- a/src/stipple/rendering.jl
+++ b/src/stipple/rendering.jl
@@ -160,6 +160,18 @@ end
     js_attr(x)
 
 Renders a Julia expression as Javascript Expression that can be passed as an attribute value in html elements.
+### Example
+```
+using StippleUI
+
+quasar(
+  :btn__toggle,
+  fieldname = :btn_value,
+  options = js_attr([opts(label = "Off", value = false), opts(label = "On", value = true)])
+)
+
+# "<q-btn-toggle v-model=\\"btn_value\\" :options=\\"[{'value':false,'label':'Off'}, {'value':true,'label':'On'}]\\"></q-btn-toggle>"
+```
 """
 function js_attr(x)
   Symbol(replace(json(render(x)), "'" => raw"\'", '"' => '''))

--- a/src/stipple/rendering.jl
+++ b/src/stipple/rendering.jl
@@ -155,3 +155,12 @@ Default rendering of `Reactive` values. Specialize `Stipple.render` to define cu
 function Stipple.render(o::Reactive{T}, fieldname::Union{Symbol,Nothing} = nothing) where {T}
   Stipple.render(o[], fieldname)
 end
+
+"""
+    js_attr(x)
+
+Renders a Julia expression as Javascript Expression that can be passed as an attribute value in html elements.
+"""
+function js_attr(x)
+  Symbol(replace(json(render(x)), "'" => raw"\'", '"' => '''))
+end


### PR DESCRIPTION
Typical use case
```julia
using StippleUI

 quasar(
    :btn__toggle,
    fieldname = :btn_value,
    options = js_attr([opts(label = "Off", value = false), opts(label = "On", value = true)])
 )

# "<q-btn-toggle v-model=\"btn_value\" :options=\"[{'value':false,'label':'Off'}, {'value':true,'label':'On'}]\"></q-btn-toggle>"
```

Furthermore, a final fix for JSONText was necessary...
