### PR TITLE
add automatic json conversion for attributes

### DIFF
--- a/src/Layout.jl
+++ b/src/Layout.jl
@@ -114,6 +114,10 @@ function flexgrid_kwargs(; class = "", class! = nothing, symbol_class::Bool = tr
   # while class will contain a js expression as Symbol
   # if either class is a Symbol or class! is not nothing.
   # So an argument of the form `class! = "'my-class' + 'your-class'` is supported
+  # Furthermore Vectors are now supported
+  class isa Vector && (class = Symbol(join(js_attr.(class), " + ")))
+  class! isa Vector && (class! = join(js_attr.(class!), " + "))
+  
   classes = String[]
   if class isa Symbol
     class! !== nothing && (class = Symbol("$class! + $class"))

--- a/src/Stipple.jl
+++ b/src/Stipple.jl
@@ -927,9 +927,10 @@ function attributes(kwargs::Union{Vector{<:Pair}, Base.Iterators.Pairs, Dict},
     end
 
     v_isa_jsexpr = v isa Symbol || !isa(v, Union{AbstractString, Bool, Number})
-    attr_key = string((v_isa_jsexpr && ! startswith(string(k), ":") &&
-                ! ( startswith(string(k), "v-") || startswith(string(k), "v" * Genie.config.html_parser_char_dash) ) ? ":" : ""), "$k") |> Symbol
-    attr_val = if isa(v, Symbol) && ! startswith(string(k), ":")
+    k_str = string(k)
+    attr_key = string((v_isa_jsexpr && ! startswith(k_str, ":") &&
+                ! (endswith(k_str, "!") || startswith(k_str, "v-") || startswith(k_str, "v" * Genie.config.html_parser_char_dash)) ? ":" : ""), "$k") |> Symbol
+    attr_val = if isa(v, Symbol) && ! startswith(k_str, ":")
       Stipple.julia_to_vue(v)
     elseif v isa Symbol || ! v_isa_jsexpr
       v

--- a/src/Stipple.jl
+++ b/src/Stipple.jl
@@ -926,10 +926,16 @@ function attributes(kwargs::Union{Vector{<:Pair}, Base.Iterators.Pairs, Dict},
       k = mappings[string(k)]
     end
 
-    attr_key = string((isa(v, Symbol) && ! startswith(string(k), ":") &&
+    v_isa_jsexpr = v isa Symbol || !isa(v, Union{AbstractString, Bool, Number})
+    attr_key = string((v_isa_jsexpr && ! startswith(string(k), ":") &&
                 ! ( startswith(string(k), "v-") || startswith(string(k), "v" * Genie.config.html_parser_char_dash) ) ? ":" : ""), "$k") |> Symbol
-    attr_val = isa(v, Symbol) && ! startswith(string(k), ":") ? Stipple.julia_to_vue(v) : v
-
+    attr_val = if isa(v, Symbol) && ! startswith(string(k), ":")
+      Stipple.julia_to_vue(v)
+    elseif v isa Symbol || ! v_isa_jsexpr
+      v
+    else
+      js_attr(v)
+    end
     attrs[attr_key] = attr_val
   end
 

--- a/src/Stipple.jl
+++ b/src/Stipple.jl
@@ -921,15 +921,16 @@ function attributes(kwargs::Union{Vector{<:Pair}, Base.Iterators.Pairs, Dict},
   for (k,v) in kwargs
     v === nothing && continue
     mapped = false
-
-    if haskey(mappings, string(k))
-      k = mappings[string(k)]
-    end
-
-    v_isa_jsexpr = v isa Symbol || !isa(v, Union{AbstractString, Bool, Number})
+    
     k_str = string(k)
+
+    if haskey(mappings, k_str)
+      k_str = mappings[k_str]
+    end
+    
+    v_isa_jsexpr = v isa Symbol || !isa(v, Union{AbstractString, Bool, Number})
     attr_key = string((v_isa_jsexpr && ! startswith(k_str, ":") &&
-                ! (endswith(k_str, "!") || startswith(k_str, "v-") || startswith(k_str, "v" * Genie.config.html_parser_char_dash)) ? ":" : ""), "$k") |> Symbol
+                ! (endswith(k_str, "!") || startswith(k_str, "v-") || startswith(k_str, "v" * Genie.config.html_parser_char_dash)) ? ":" : ""), k_str) |> Symbol
     attr_val = if isa(v, Symbol) && ! startswith(k_str, ":")
       Stipple.julia_to_vue(v)
     elseif v isa Symbol || ! v_isa_jsexpr


### PR DESCRIPTION
This PR addresses #231.

It requires adaptation of the respective functions in StippleUI to allow for Vectors or Dicts.

E.g. with
```julia
function btntoggle(fieldname::Symbol,
                args...;
                options::Union{Symbol, Vector{<:AbstractDict}},
                kwargs...)

  q__btn__toggle(args...; kw(
    [Symbol(":options") => options, :fieldname => fieldname, kwargs...])...)
end
```
we could write
```julia
julia> import Stipple.opts

julia> btntoggle(:network, options = [opts(label = x, value = lowercase(x)) for x in ("Google", "Facebook")])
"<q-btn-toggle v-model=\"network\" :options=\"[{'value':'google','label':'Google'},{'value':'facebook','label':'Facebook'}]\"></q-btn-toggle>"

julia> select(:selector, options = ["a", "b", "c"],)
"<q-select v-model=\"selector\" :options=\"['a','b','c']\"></q-select>"
```