### PR TITLE
rename vue attribute macros to `@if`, `@else`, `@elseif` and `@for`

### DIFF
--- a/docs/src/API/elements.md
+++ b/docs/src/API/elements.md
@@ -7,10 +7,10 @@ root
 elem
 vm
 vue_integration
-@iif
-@elsiif
-@els
-@recur
+@if
+@elseif
+@else
+@for
 @text
 @bind
 @data

--- a/src/Elements.jl
+++ b/src/Elements.jl
@@ -10,8 +10,11 @@ using Stipple
 
 import Genie.Renderer.Html: HTMLString, normal_element
 
-export root, elem, vm, @iif, @elsiif, @els, @recur, @text, @bind, @data, @on, @click, @showif
+export root, elem, vm, @if, @else, @elseif, @for, @text, @bind, @data, @on, @click, @showif
 export stylesheet, kw_to_str
+
+# deprecated
+export @iif, @elsiif, @els, @recur
 
 #===#
 
@@ -154,7 +157,7 @@ function kw_to_str(; kwargs...)
 end
 
 """
-    @iif(expr)
+    @if(expr)
 
 Generates `v-if` Vue.js code using `expr` as the condition.
 <https://vuejs.org/v2/api/#v-if>
@@ -162,16 +165,16 @@ Generates `v-if` Vue.js code using `expr` as the condition.
 ### Example
 
 ```julia
-julia> span("Bad stuff's about to happen", class="warning", @iif(:warning))
+julia> span("Bad stuff's about to happen", class="warning", @if(:warning))
 "<span class=\"warning\" v-if='warning'>Bad stuff's about to happen</span>"
 ```
 """
-macro iif(expr)
+macro var"if"(expr)
   Expr(:kw, Symbol("v-if"), esc_expr(expr))
 end
 
 """
-    @elsiif(expr)
+    @elseif(expr)
 
 Generates `v-else-if` Vue.js code using `expr` as the condition.
 <https://vuejs.org/v2/api/#v-else-if>
@@ -179,16 +182,16 @@ Generates `v-else-if` Vue.js code using `expr` as the condition.
 ### Example
 
 ```julia
-julia> span("An error has occurred", class="error", @elsiif(:error))
+julia> span("An error has occurred", class="error", @elseif(:error))
 "<span class=\"error\" v-else-if='error'>An error has occurred</span>"
 ```
 """
-macro elsiif(expr)
+macro var"elseif"(expr)
   Expr(:kw, Symbol("v-else-if"), esc_expr(expr))
 end
 
 """
-    @els(expr)
+    @else(expr)
 
 Generates `v-else` Vue.js code using `expr` as the condition.
 <https://vuejs.org/v2/api/#v-else>
@@ -196,11 +199,11 @@ Generates `v-else` Vue.js code using `expr` as the condition.
 ### Example
 
 ```julia
-julia> span("Might want to keep an eye on this", class="notice", @els(:notice))
+julia> span("Might want to keep an eye on this", class="notice", @else(:notice))
 "<span class=\"notice\" v-else='notice'>Might want to keep an eye on this</span>"
 ```
 """
-macro els(expr)
+macro var"else"(expr)
   Expr(:kw, Symbol("v-else"), esc_expr(expr))
 end
 
@@ -211,13 +214,46 @@ Generates `v-for` directive to render a list of items based on an array.
 ### Example
 
 ```julia
-julia> p(" {{todo}} ", class="warning", @recur(:"todo in todos"))
+julia> p(" {{todo}} ", class="warning", @for(:"todo in todos"))
 "<p v-for='todo in todos'>\n {{todo}} \n</p>\n"
 ```
 
 """
-macro recur(expr)
+macro var"for"(expr)
   Expr(:kw, Symbol("v-for"), esc_expr(expr))
+end
+
+
+"""
+`@recur` is deprecated and has been replaced by `@for`.
+It is kept for compatibility reasons and will be removed in a future release.
+"""
+macro iif(expr)
+  esc(:(@if($expr)))
+end
+
+"""
+`@recur` is deprecated and has been replaced by `@for`.
+It is kept for compatibility reasons and will be removed in a future release.
+"""
+macro els(expr)
+  esc(:(@else($expr)))
+end
+
+"""
+`@recur` is deprecated and has been replaced by `@for`.
+It is kept for compatibility reasons and will be removed in a future release.
+"""
+macro elsiif(expr)
+  esc(:(@elseif($expr)))
+end
+
+"""
+`@recur` is deprecated and has been replaced by `@for`.
+It is kept for compatibility reasons and will be removed in a future release.
+"""
+macro recur(expr)
+  esc(:(@for($expr)))
 end
 
 """

--- a/src/Elements.jl
+++ b/src/Elements.jl
@@ -169,11 +169,12 @@ julia> span("Bad stuff's about to happen", class="warning", @if(:warning))
 "<span class=\"warning\" v-if='warning'>Bad stuff's about to happen</span>"
 ```
 """
-macro var"if"(expr)
+macro iif(expr)
   Expr(:kw, Symbol("v-if"), esc_expr(expr))
 end
+const var"@if" = var"@iif"
 
-"""
+  """
     @elseif(expr)
 
 Generates `v-else-if` Vue.js code using `expr` as the condition.
@@ -186,9 +187,10 @@ julia> span("An error has occurred", class="error", @elseif(:error))
 "<span class=\"error\" v-else-if='error'>An error has occurred</span>"
 ```
 """
-macro var"elseif"(expr)
+macro elsiif(expr)
   Expr(:kw, Symbol("v-else-if"), esc_expr(expr))
 end
+const var"@elseif" = var"@elsiif"
 
 """
     @else(expr)
@@ -203,9 +205,10 @@ julia> span("Might want to keep an eye on this", class="notice", @else(:notice))
 "<span class=\"notice\" v-else='notice'>Might want to keep an eye on this</span>"
 ```
 """
-macro var"else"(expr)
+macro els(expr)
   Expr(:kw, Symbol("v-else"), esc_expr(expr))
 end
+const var"@else" = var"@els"
 
 """
 Generates `v-for` directive to render a list of items based on an array.
@@ -219,42 +222,10 @@ julia> p(" {{todo}} ", class="warning", @for(:"todo in todos"))
 ```
 
 """
-macro var"for"(expr)
+macro recur(expr)
   Expr(:kw, Symbol("v-for"), esc_expr(expr))
 end
-
-
-"""
-`@recur` is deprecated and has been replaced by `@for`.
-It is kept for compatibility reasons and will be removed in a future release.
-"""
-macro iif(expr)
-  esc(:(@if($expr)))
-end
-
-"""
-`@recur` is deprecated and has been replaced by `@for`.
-It is kept for compatibility reasons and will be removed in a future release.
-"""
-macro els(expr)
-  esc(:(@else($expr)))
-end
-
-"""
-`@recur` is deprecated and has been replaced by `@for`.
-It is kept for compatibility reasons and will be removed in a future release.
-"""
-macro elsiif(expr)
-  esc(:(@elseif($expr)))
-end
-
-"""
-`@recur` is deprecated and has been replaced by `@for`.
-It is kept for compatibility reasons and will be removed in a future release.
-"""
-macro recur(expr)
-  esc(:(@for($expr)))
-end
+const var"@for" = var"@recur"
 
 """
     @text(expr)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -352,6 +352,23 @@ end
     @test cell(col = -1, sm = 9) == "<div class=\"st-col col-sm-9\"></div>"
 end
 
+@testset "Vue Conditionals and Iterator" begin
+    el = column("Hello", @if(:visible))
+    @test contains(el, "v-if=\"visible\"")
+
+    el = column("Hello", @else(:visible))
+    @test contains(el, "v-else=\"visible\"")
+
+    el = column("Hello", @elseif(:visible))
+    @test contains(el, "v-else-if=\"visible\"")
+
+    el = row(@showif("n > 0"), "The result is '{{ n }}'")
+    @test el == "<div v-show=\"n > 0\" class=\"row\">The result is '{{ n }}'</div>"
+
+    el = row(@for("i in [1, 2, 3, 4, 5]"), "{{ i }}")
+    @test contains(el, "v-for=\"i in [1, 2, 3, 4, 5]\"")
+end
+
 @testset "Compatibility of JSONText between JSON3 and JSON" begin
     using JSON
     using Stipple


### PR DESCRIPTION
Currently we have `@iif`, `@els`, `@elsiif`and `@recur` defined due to name clashes with Julia's reserved words.
From version 1.10 on one can get around that by defining a `macro var"if"`.
However in order to be compatible, macro aliasing is a better way. So we keep the old definitions and alias them like
```julia
const var"@if" = var"@iif"
```
We even get the docstring right if we use it in the REPL:
```
help?> @if
  @if(expr)

  Generates v-if Vue.js code using expr as the condition. https://vuejs.org/v2/api/#v-if (https://vuejs.org/v2/api/#v-if)

  Example
  –––––––

  julia> span("Bad stuff's about to happen", class="warning", @if(:warning))
  "<span class="warning" v-if='warning'>Bad stuff's about to happen</span>"
```
