### PR TITLE
fix handling of ParsedHTML in `@page` macro

### DIFF
--- a/src/Pages.jl
+++ b/src/Pages.jl
@@ -48,9 +48,12 @@ function Page(  route::Union{Route,String};
           else
             model
           end
-
-  view =  if isa(view, ParsedHTMLString) || isa(view, Vector{<:AbstractString})
-            string(view)
+  view =  if isa(view, Function) || isa(view, ParsedHTMLString)
+            view
+          elseif isa(view, Vector{ParsedHTMLString})
+            ParsedHTMLString(view)
+          elseif isa(view, Vector{<:AbstractString})
+            join(view)
           elseif isa(view, AbstractString)
             isfile(view) ? filepath(view) : view
           else

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -382,8 +382,10 @@ end
 
 @testset "@page macro with ParsedHTMLStrings" begin
     using Genie.HTTPUtils.HTTP
-    up()
-
+    
+    port = rand(8001:9000)
+    up(;port, ws_port = port)
+    
     # rand is needed to avoid re-using cached routes
     view() = [ParsedHTMLString("""<div id="test" @click="i = i+1">Change @click</div>"""), a("test $(rand(1:10^10))")]
     p1 = view()[1]
@@ -392,13 +394,13 @@ end
 
     # route function resulting in ParsedHTMLString
     @page("/", ui)
-    payload = String(HTTP.payload(HTTP.get("http://127.0.0.1:8000")))
+    payload = String(HTTP.payload(HTTP.get("http://127.0.0.1:$port")))
     @test match(r"<div id=\"test\" .*?div>", payload).match == p1
     @test contains(payload, """<link href="/stipple.jl/master/assets/css/stipplecore.css""")
 
     # route constant ParsedHTMLString
     @page("/", ui())
-    payload = String(HTTP.payload(HTTP.get("http://127.0.0.1:8000")))
+    payload = String(HTTP.payload(HTTP.get("http://127.0.0.1:$port")))
     @test match(r"<div id=\"test\" .*?div>", payload).match == p1 
     @test contains(payload, """<link href="/stipple.jl/master/assets/css/stipplecore.css""")
     
@@ -408,7 +410,7 @@ end
 
     # route function resulting in Vector{ParsedHTMLString}
     @page("/", ui)
-    payload = String(HTTP.payload(HTTP.get("http://127.0.0.1:8000")))
+    payload = String(HTTP.payload(HTTP.get("http://127.0.0.1:$port")))
     @test match(r"<div id=\"test\" .*?div>", payload).match == p1
     @test contains(payload, r"<a>test \d+</a>")
 
@@ -416,7 +418,7 @@ end
 
     # route constant Vector{ParsedHTMLString}
     @page("/", ui())
-    payload = String(HTTP.payload(HTTP.get("http://127.0.0.1:8000")))
+    payload = String(HTTP.payload(HTTP.get("http://127.0.0.1:$port")))
     @test match(r"<div id=\"test\" .*?div>", payload).match == p1 
     @test contains(payload, """<link href="/stipple.jl/master/assets/css/stipplecore.css""")
 
@@ -426,14 +428,14 @@ end
     
     # route function resulting in String
     @page("/", ui)
-    payload = String(HTTP.payload(HTTP.get("http://127.0.0.1:8000")))
+    payload = String(HTTP.payload(HTTP.get("http://127.0.0.1:$port")))
     @test match(r"<div id=\"test\" .*?div>", payload).match != p1
     @test contains(payload, """<link href="/stipple.jl/master/assets/css/stipplecore.css""")
     @test contains(payload, r"<a>test \d+</a>")
     
     # route constant String
     @page("/", ui())
-    payload = String(HTTP.payload(HTTP.get("http://127.0.0.1:8000")))
+    payload = String(HTTP.payload(HTTP.get("http://127.0.0.1:$port")))
     @test match(r"<div id=\"test\" .*?div>", payload).match != p1
     @test contains(payload, """<link href="/stipple.jl/master/assets/css/stipplecore.css""")
     @test contains(payload, r"<a>test \d+</a>")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -384,23 +384,59 @@ end
     using Genie.HTTPUtils.HTTP
     up()
 
-    p1, p2 = ParsedHTMLString("""<q-btn @click="i = i+1">Change @click $(randstring(10))</q-btn>"""), ParsedHTMLString("<a></a>")
-    ui() = p1
+    # rand is needed to avoid re-using cached routes
+    view() = [ParsedHTMLString("""<div id="test" @click="i = i+1">Change @click</div>"""), a("test $(rand(1:10^10))")]
+    p1 = view()[1]
+    
+    ui() = ParsedHTMLString(view())
+
+    # route function resulting in ParsedHTMLString
     @page("/", ui)
     payload = String(HTTP.payload(HTTP.get("http://127.0.0.1:8000")))
-    @test match(r"<q-btn.*q-btn>", payload).match == p1 
-    @test contains(payload, """<link href="/stippleui.jl/master/assets/""")
+    @test match(r"<div id=\"test\" .*?div>", payload).match == p1
+    @test contains(payload, """<link href="/stipple.jl/master/assets/css/stipplecore.css""")
 
+    # route constant ParsedHTMLString
     @page("/", ui())
     payload = String(HTTP.payload(HTTP.get("http://127.0.0.1:8000")))
-    @test match(r"<q-btn.*q-btn>", payload).match == p1 
-    @test contains(payload, """<link href="/stippleui.jl/master/assets/""")
+    @test match(r"<div id=\"test\" .*?div>", payload).match == p1 
+    @test contains(payload, """<link href="/stipple.jl/master/assets/css/stipplecore.css""")
     
-    # Supply a String instead of a ParsedHTMLString. As the '@' character is not correctly parsed, this test fails
-    @page("/", ui().data)
+    # ----------------------------
+
+    ui() = view()
+
+    # route function resulting in Vector{ParsedHTMLString}
+    @page("/", ui)
     payload = String(HTTP.payload(HTTP.get("http://127.0.0.1:8000")))
-    @test match(r"<q-btn.*q-btn>", payload).match != p1
-    @test contains(payload, """<link href="/stippleui.jl/master/assets/""")
+    @test match(r"<div id=\"test\" .*?div>", payload).match == p1
+    @test contains(payload, r"<a>test \d+</a>")
+
+    @test contains(payload, """<link href="/stipple.jl/master/assets/css/stipplecore.css""")
+
+    # route constant Vector{ParsedHTMLString}
+    @page("/", ui())
+    payload = String(HTTP.payload(HTTP.get("http://127.0.0.1:8000")))
+    @test match(r"<div id=\"test\" .*?div>", payload).match == p1 
+    @test contains(payload, """<link href="/stipple.jl/master/assets/css/stipplecore.css""")
+
+    # Supply a String instead of a ParsedHTMLString.
+    # As the '@' character is not correctly parsed, the match is expected to differ
+    ui() = join(view())
+    
+    # route function resulting in String
+    @page("/", ui)
+    payload = String(HTTP.payload(HTTP.get("http://127.0.0.1:8000")))
+    @test match(r"<div id=\"test\" .*?div>", payload).match != p1
+    @test contains(payload, """<link href="/stipple.jl/master/assets/css/stipplecore.css""")
+    @test contains(payload, r"<a>test \d+</a>")
+    
+    # route constant String
+    @page("/", ui())
+    payload = String(HTTP.payload(HTTP.get("http://127.0.0.1:8000")))
+    @test match(r"<div id=\"test\" .*?div>", payload).match != p1
+    @test contains(payload, """<link href="/stipple.jl/master/assets/css/stipplecore.css""")
+    @test contains(payload, r"<a>test \d+</a>")
 
     down()
 end


### PR DESCRIPTION
Currently, routing of ParsedHTMLString is broken in two ways:
- ParsedHTMLValues and vectors thereof are not correctly handled by `html()`; layout and model are ignored
- content of functions that generate ParsedHTML or vectors thereof is parsed; it is therefore impossible to route content that is not correctly parsed, e.g. `'@'` characters (cf. https://github.com/GenieFramework/Stipple.jl/issues/164)

This PR fixes both shortcomings together with a respective fix in Genie.

