### PR TITLE
refactor reviver

### DIFF
--- a/assets/js/watchers.js
+++ b/assets/js/watchers.js
@@ -54,20 +54,13 @@ const watcherMixin = {
 
 const reviveMixin = {
   methods: {
-    revive_payload: function(obj) {
-      if (typeof obj === 'object') {
-        for (var key in obj) {
-          if ( (typeof obj[key] === 'object') && (obj[key]!=null) && !(obj[key].jsfunction) ) {
-            this.revive_payload(obj[key])
-          } else {
-            if ( (obj[key]!=null) && (obj[key].jsfunction) ) {
-              obj[key] = Function(obj[key].jsfunction.arguments, obj[key].jsfunction.body)
-            }
-          }
-        }
+    revive_jsfunction: function (k, v) {
+      if ( (typeof v==='object') && (v!=null) && (v.jsfunction) ) {
+        return Function(v.jsfunction.arguments, v.jsfunction.body)
+      } else {
+        return v
       }
-      return obj;
-    }
+     }
   }
 }
 

--- a/src/Elements.jl
+++ b/src/Elements.jl
@@ -97,14 +97,13 @@ function vue_integration(::Type{M};
 
   window.parse_payload = function(payload){
     if (payload.key) {
-      window.$(vue_app_name).revive_payload(payload)
-      window.$(vue_app_name).updateField(payload.key, payload.value);
+       window.$(vue_app_name).updateField(payload.key, payload.value);
     }
   }
 
   function app_ready() {
       $vue_app_name.isready = true;
-
+      Genie.addReviver(window.$(vue_app_name).revive_jsfunction);
       $(transport == Genie.WebChannels &&
       "
       try {

--- a/src/Elements.jl
+++ b/src/Elements.jl
@@ -12,7 +12,7 @@ using MacroTools
 import Genie.Renderer.Html: HTMLString, normal_element
 
 export root, elem, vm, @if, @else, @elseif, @for, @text, @bind, @data, @on, @click, @showif
-export stylesheet, kw_to_str
+export stylesheet, kw_to_str, js_add_reviver
 
 # deprecated
 export @iif, @elsiif, @els, @recur
@@ -40,6 +40,14 @@ function elem(app::M)::String where {M<:ReactiveModel}
 end
 
 const vm = root
+
+function js_add_reviver(revivername::String)
+  """
+  Genie.WebChannels.subscriptionHandlers.push(function(event) {
+      Genie.Revivers.addReviver($revivername);
+  });
+  """
+end
 
 #===#
 
@@ -103,7 +111,7 @@ function vue_integration(::Type{M};
 
   function app_ready() {
       $vue_app_name.isready = true;
-      Genie.addReviver(window.$(vue_app_name).revive_jsfunction);
+      Genie.Revivers.addReviver(window.$(vue_app_name).revive_jsfunction);
       $(transport == Genie.WebChannels &&
       "
       try {

--- a/src/ReactiveTools.jl
+++ b/src/ReactiveTools.jl
@@ -13,6 +13,9 @@ export @readonly, @private, @in, @out, @jsfn, @readonly!, @private!, @in!, @out!
 #definition of handlers/events
 export @onchange, @onbutton, @event, @notify
 
+# definition of dependencies
+export @deps, @clear_deps
+
 # deletion
 export @clear, @clear_vars, @clear_handlers
 
@@ -1299,6 +1302,71 @@ __init()
 macro modelstorage()
   quote
     using Stipple.ModelStorage.Sessions
+  end |> esc
+end
+
+"""
+  @deps f
+
+
+Add a function f to the dependencies of the current app.
+
+------------------------
+
+  @deps M::Module
+
+  
+Add the dependencies of the module M to the dependencies of the current app.
+"""
+macro deps(expr)
+  quote
+    Stipple.deps!(Stipple.@type(), $expr)
+  end |> esc
+end
+
+"""
+  @deps(MyApp::ReactiveModel, f::Function)
+
+
+Add a function f to the dependencies of the app MyApp.
+The module needs to define a function `deps()`.
+
+------------------------
+
+  @deps(MyApp::ReactiveModel, M::Module)
+
+  
+Add the dependencies of the module M to the dependencies of the app MyApp.
+The module needs to define a function `deps()`.
+"""
+macro deps(M, expr)
+  quote
+    Stipple.deps!($M, $expr)
+  end |> esc
+end
+
+"""
+  @clear_deps
+
+
+Delete all dependencies of the current app.
+
+------------------------
+
+  @clear_deps MyApp
+
+
+Delete all dependencies of the app MyApp.
+"""
+macro clear_deps()
+  quote
+    Stipple.clear_deps!(Stipple.@type())
+  end |> esc
+end
+
+macro clear_deps(M)
+  quote
+    Stipple.clear_deps!($M)
   end |> esc
 end
 

--- a/src/Stipple.jl
+++ b/src/Stipple.jl
@@ -741,12 +741,8 @@ function injectdeps(output::Vector{AbstractString}, M::Type{<:ReactiveModel}) ::
     push!(output, DEPS[AM]()...)
     # furthermore, include deps who's keys start with "_<name of the ReactiveModel>_"
     model_prefix = "_$(vm(AM))_"
-    @show model_prefix
     for (key, f) in DEPS
-      println("hi 1")
-      @show key
       key isa Symbol || continue
-      @show startswith("$key", model_prefix)
       startswith("$key", model_prefix) && push!(output, f()...)
     end
   end

--- a/src/Stipple.jl
+++ b/src/Stipple.jl
@@ -731,11 +731,25 @@ end
 function injectdeps(output::Vector{AbstractString}, M::Type{<:ReactiveModel}) :: Vector{AbstractString}
   for (key, f) in DEPS
     key isa DataType && key <: ReactiveModel && continue
+    # exclude keys starting with '_' 
+    key isa Symbol && startswith("$key", '_') && continue
     push!(output, f()...)
   end
   AM = get_abstract_type(M)
-  haskey(DEPS, AM) && push!(output, DEPS[AM]()...)
-
+  if haskey(DEPS, AM)
+    # DEPS[AM] contains the stipple-generated deps
+    push!(output, DEPS[AM]()...)
+    # furthermore, include deps who's keys start with "_<name of the ReactiveModel>_"
+    model_prefix = "_$(vm(AM))_"
+    @show model_prefix
+    for (key, f) in DEPS
+      println("hi 1")
+      @show key
+      key isa Symbol || continue
+      @show startswith("$key", model_prefix)
+      startswith("$key", model_prefix) && push!(output, f()...)
+    end
+  end
   output
 end
 
@@ -772,6 +786,29 @@ end
 
 function deps!(m::Any, f::Function)
   DEPS[m] = f
+end
+
+function deps!(m::Any, M::Module)
+  DEPS[m] = M.deps
+end
+
+function deps!(M::Type{<:ReactiveModel}, f::Function; extra_deps = true)
+  key = extra_deps ? Symbol("_$(vm(M))_$(nameof(f))") : M
+  DEPS[key] = f isa Function ? f : f.deps 
+end
+
+deps!(M::Type{<:ReactiveModel}, modul::Module; extra_deps = true) = deps!(M, modul.deps; extra_deps)
+
+deps!(m::Any, v::Vector{Union{Function, Module}}) = deps!.(Ref(m), v)
+deps!(m::Any, t::Tuple) = [deps!(m, f) for f in t]
+deps!(m, args...) = [deps!(m, f) for f in args]
+
+function clear_deps!(M::Type{<:ReactiveModel})
+  delete!(DEPS, M)
+  model_prefix = "_$(vm(M))_"
+  for k in keys(Stipple.DEPS)
+    k isa Symbol && startswith("$k", model_prefix) && delete!(DEPS, k)
+  end
 end
 
 @specialize

--- a/src/stipple/rendering.jl
+++ b/src/stipple/rendering.jl
@@ -112,6 +112,7 @@ Stipple.stipple_parse(::Complex, z::Dict{String, Any}) = float(z["re"]) + z["im"
 ```
 """
 jsrender(x, args...) = render(x, args...)
+jsrender(r::Reactive, args...) = jsrender(getfield(getfield(r,:o), :val), args...)
 
 """
     function Stipple.render(app::M, fieldname::Union{Symbol,Nothing} = nothing)::Dict{Symbol,Any} where {M<:ReactiveModel}

--- a/src/stipple/rendering.jl
+++ b/src/stipple/rendering.jl
@@ -94,6 +94,26 @@ function julia_to_vue(field, mapping_keys = mapping_keys()) :: String
 end
 
 """
+    jsrender(x, args...)
+
+Defines separate rendering for the Vue instance. This method is only necessary for non-standard types that
+are not transmittable by regular json. Such types need a reviver to be transmitted via json and (optionally)
+a render method that is only applied for the rendering of the model.
+The model is not transmitted via json but via a js-file. So there it is possible to define non-serializable values.
+
+### Example
+
+```
+Stipple.render(z::Complex) = Dict(:mathjs => "Complex", :re => z.re, :im => z.im)
+function Stipple.jsrender(z::Union{Complex, R{<:Complex}}, args...)
+    JSONText("math.complex('\$(replace(strip(repr(Observables.to_value(z)), '"'), 'm' => ""))')")
+end
+Stipple.stipple_parse(::Complex, z::Dict{String, Any}) = float(z["re"]) + z["im"]
+```
+"""
+jsrender(x, args...) = render(x, args...)
+
+"""
     function Stipple.render(app::M, fieldname::Union{Symbol,Nothing} = nothing)::Dict{Symbol,Any} where {M<:ReactiveModel}
 
 Renders the Julia `ReactiveModel` `app` as the corresponding Vue.js JavaScript code.
@@ -107,7 +127,7 @@ function Stipple.render(app::M)::Dict{Symbol,Any} where {M<:ReactiveModel}
     occursin(SETTINGS.private_pattern, String(field)) && continue
     f isa Reactive && f.r_mode == PRIVATE && continue
 
-    result[julia_to_vue(field)] = Stipple.render(f, field)
+    result[julia_to_vue(field)] = Stipple.jsrender(f, field)
   end
 
   vue = Dict( :el => JSONText("rootSelector"),


### PR DESCRIPTION
I refactored the Genie's reviver for easier implementation of user-defined revivers. (https://github.com/GenieFramework/Genie.jl/pull/690)

Users can now use the javascript function `Genie.addReviver(f)`

This makes the construction of a StippleMathjs.jl (see https://github.com/GenieFramework/Stipple.jl/issues/235) very easy.

-------------------

This solution was greatly inspired by https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse