### PR TITLE
Fix invalid session key

### DIFF
--- a/src/Stipple.jl
+++ b/src/Stipple.jl
@@ -466,7 +466,7 @@ function init(::Type{M};
 
       try
         haskey(payload, "sesstoken") && ! isempty(payload["sesstoken"]) &&
-          Genie.Router.params!(:session,
+          Genie.Router.params!(Stipple.ModelStorage.Sessions.GenieSession.PARAMS_SESSION_KEY,
                                 Stipple.ModelStorage.Sessions.GenieSession.load(payload["sesstoken"] |> Genie.Encryption.decrypt))
       catch ex
         @error ex


### PR DESCRIPTION
Fixes https://github.com/GenieFramework/Stipple.jl/issues/242

It reverts one of the changes made as part of [this commit](https://github.com/GenieFramework/Stipple.jl/commit/6aeeba96e5d4d2fdaea6dcc699304167b3e064cc#diff-39019d8ae899bcdd3758db28f205d5c546be80ab59858397e829ce82fa2e9f38), where key Router.params() key `:SESSION` has been replaced with `:session`. 

This has caused problems downstream with GenieAuthentication.