### PR TITLE
Support except and restrict in `push!()` and run()`

### DIFF
--- a/assets/js/watchers.js
+++ b/assets/js/watchers.js
@@ -81,8 +81,9 @@ const reviveMixin = {
 
 const eventMixin = {
   methods: {
-    handle_event: function (event_data, event_handler) {
+    handle_event: function (event_data, event_handler, mode) {
       console.debug('event: ' + JSON.stringify(event_data) + ":" + event_handler)
+      if (mode=='addclient') { event_data._addclient = true}
       Genie.WebChannels.sendMessageTo(window.CHANNEL, 'events', {
           'event': {
               'name': event_handler,

--- a/src/Elements.jl
+++ b/src/Elements.jl
@@ -359,6 +359,7 @@ Sometimes preprocessing of the events is necessary, e.g. to add or skip informat
 ```
 """
 macro on(arg, expr, preprocess = nothing)
+  preprocess isa QuoteNode && preprocess == :(:addclient) && (preprocess = "event._addclient = true")
   kw = Symbol("v-on:", arg isa String ? arg : arg isa QuoteNode ? arg.value : arg.head == :vect ? join(lstrip.(string.(arg.args), ':'), '.') :
     throw("Value '$arg' for `arg` not supported. `arg` should be of type Symbol, String, or Vector{Union{String, Symbol}}"))
 
@@ -370,7 +371,7 @@ macro on(arg, expr, preprocess = nothing)
           :(replace("""function(event) {
               const preprocess = (event) => { """ * replace($preprocess, '"' => "\\\"") * """; return event }
               handle_event(preprocess(event), '$($(esc(expr)))')
-          }'""", '\n' => ';'))
+          }""", '\n' => ';'))
       end
   else
       esc_expr(expr)

--- a/src/Stipple.jl
+++ b/src/Stipple.jl
@@ -525,6 +525,13 @@ function init(::Type{M};
       # form handler parameter & call event notifier
       handler = Symbol(get(event, "name", nothing))
       event_info = get(event, "event", nothing)
+      
+      # add client id if requested
+      if event_info isa Dict && get(event_info, "_addclient", false)
+        client = transport == Genie.WebChannels ? Genie.WebChannels.id(Genie.Requests.wsclient()) : Genie.Requests.wtclient()
+        push!(event_info, "_client" => client)
+      end
+      
       isempty(methods(notify, (M, Val{handler}))) || notify(model, Val(handler))
       isempty(methods(notify, (M, Val{handler}, Any))) || notify(model, Val(handler), event_info)
       LAST_ACTIVITY[Symbol(channel)] = now()

--- a/src/Stipple.jl
+++ b/src/Stipple.jl
@@ -620,7 +620,7 @@ const max_retry_times = 10
 Pushes data payloads over to the frontend by broadcasting the `vals` through the `channel`.
 """
 function Base.push!(app::M, vals::Pair{Symbol,T};
-                    channel::String = getchannel(model),
+                    channel::String = getchannel(app),
                     except::Union{Nothing,UInt,Vector{UInt}} = nothing,
                     restrict::Union{Nothing,UInt,Vector{UInt}} = nothing)::Bool where {T,M<:ReactiveModel}
   try
@@ -631,16 +631,16 @@ function Base.push!(app::M, vals::Pair{Symbol,T};
   end
 end
 
-function Base.push!(model::M, vals::Pair{Symbol,Reactive{T}};
-                    channel::String = getchannel(model),
+function Base.push!(app::M, vals::Pair{Symbol,Reactive{T}};
+                    channel::String = getchannel(app),
                     except::Union{Nothing,UInt,Vector{UInt}} = nothing,
                     restrict::Union{Nothing,UInt,Vector{UInt}} = nothing)::Bool where {T,M<:ReactiveModel}
                     v = vals[2].r_mode != JSFUNCTION ? vals[2][] : replace_jsfunction(vals[2][])
-  push!(model, Symbol(julia_to_vue(vals[1])) => v; channel, except, restrict)
+  push!(app, Symbol(julia_to_vue(vals[1])) => v; channel, except, restrict)
 end
 
-function Base.push!(model::M;
-                    channel::String = getchannel(model),
+function Base.push!(app::M;
+                    channel::String = getchannel(app),
                     except::Union{Nothing,UInt,Vector{UInt}} = nothing,
                     restrict::Union{Nothing,UInt,Vector{UInt}} = nothing,
                     skip::Vector{Symbol} = Symbol[])::Bool where {M<:ReactiveModel}
@@ -648,20 +648,20 @@ function Base.push!(model::M;
   result = true
 
   for field in fieldnames(M)
-    (isprivate(field, model) || field in skip) && continue
+    (isprivate(field, app) || field in skip) && continue
 
-    push!(model, field => getproperty(model, field); channel, except, restrict) === false && (result = false)
+    push!(app, field => getproperty(app, field); channel, except, restrict) === false && (result = false)
   end
 
   result
 end
 
-function Base.push!(model::M, field::Symbol;
-                  channel::String = getchannel(model),
+function Base.push!(app::M, field::Symbol;
+                  channel::String = getchannel(app),
                   except::Union{Nothing,UInt,Vector{UInt}} = nothing,
                   restrict::Union{Nothing,UInt,Vector{UInt}} = nothing)::Bool where {M<:ReactiveModel}
-  isprivate(field, model) && return false
-  push!(model, field => getproperty(model, field); channel, except, restrict)
+  isprivate(field, app) && return false
+  push!(app, field => getproperty(app, field); channel, except, restrict)
 end
 
 @specialize

--- a/src/stipple/jsintegration.jl
+++ b/src/stipple/jsintegration.jl
@@ -87,9 +87,9 @@ end
 
 Execute js code in the frontend. `context` can be `:model`, `:app` or `:console`
 """
-function Base.run(model::ReactiveModel, jscode::String; context = :model)
-  context ∈ (:model, :app) && return push!(model, Symbol("js_", context) => jsfunction(jscode); channel = getchannel(model))
-  context == :console && push!(model, :js_model => jsfunction("console.log('$jscode')"); channel = getchannel(model))
+function Base.run(model::ReactiveModel, jscode::String; context = :model, kwargs...)
+  context ∈ (:model, :app) && return push!(model, Symbol("js_", context) => jsfunction(jscode); channel = getchannel(model), kwargs...)
+  context == :console && push!(model, :js_model => jsfunction("console.log('$jscode')"); channel = getchannel(model), kwargs...)
 
   nothing
 end


### PR DESCRIPTION
Currently, it is not possible to address single clients by push! or run commands.

To remedy this situation I propose to
- modify existing keyword `except` to support not only UInt, but also Vetor{UInt} to exclude more than one client
- remove `WebSocket` as a possible value for except and rather supply the id as it is done in WebThreads
- add a keyword `restrict` to restrict messages to a client or list of clients

There will be a corresponding PR in Genie.