### PR TITLE
Hh rm mixins

### DIFF
--- a/src/ReactiveTools.jl
+++ b/src/ReactiveTools.jl
@@ -656,8 +656,13 @@ macro init(args...)
         identity
       end
     end
-    instance = let model = initfn($(init_args...))
-      new_handlers ? Base.invokelatest(handlersfn, model) : handlersfn(model)
+    instance = initfn($(init_args...))
+    # append eventhandlers
+    new_handlers ? Base.invokelatest(handlersfn, instance) : handlersfn(instance)
+    # append eventhandlers of mixins
+    for mixin in Stipple.get_mixins(instance)
+      handlers = get(Stipple.ReactiveTools.HANDLERS_FUNCTIONS, mixin, nothing)
+      handlers === nothing || handlers(instance)
     end
     for p in Stipple.Pages._pages
       p.context == $__module__ && (p.model = instance)

--- a/src/ReactiveTools.jl
+++ b/src/ReactiveTools.jl
@@ -532,6 +532,10 @@ macro mixin(location, expr, prefix, postfix)
   end |> esc
 end
 
+macro mixins(location, mixins)
+  :(Stipple.get_mixins(::Type{$location}) = Type{<:ReactiveModel}[$mixins...]) |> esc
+end
+
 #===#
 
 function init_handlers(m::Module)

--- a/src/Stipple.jl
+++ b/src/Stipple.jl
@@ -766,7 +766,8 @@ function injectdeps(output::Vector{AbstractString}, M::Type{<:ReactiveModel}) ::
     mixinfields = fieldnames(Stipple.get_concrete_type(mixin))
     # if all fields are already part of the model, don't include data
     mode = isempty(setdiff(mixinfields, modelfields)) ? :mixindeps : :mixin
-    push!(output, mixin_dep(mixin; mode)())
+    out = mixin_dep(mixin; mode)()
+    out === nothing || push!(output, out)
   end
   output
 end

--- a/src/stipple/rendering.jl
+++ b/src/stipple/rendering.jl
@@ -169,7 +169,12 @@ function get_mixins(app::ReactiveModel)::Vector{ReactiveModel}
 end
 
 function mixin_dep(Mixin::Type{<:ReactiveModel}; mode::Symbol = :mixindeps)
-  mixin_dep() = script("const $(nameof(Mixin)) = $(strip(json(render(Mixin(); mode)), '"'))\n")
+  mix = strip(json(render(Mixin(); mode)), '"')
+  mixin_dep() = if mix == "{}"
+    nothing
+  else
+    script("const $(nameof(Mixin)) = $mix\n")
+  end
 end
 
 

--- a/src/stipple/rendering.jl
+++ b/src/stipple/rendering.jl
@@ -121,8 +121,9 @@ Renders the Julia `ReactiveModel` `app` as the corresponding Vue.js JavaScript c
 """
 function Stipple.render(app::M; mode::Symbol = :vue)::LittleDict{Symbol,Any} where {M<:ReactiveModel}
   result = LittleDict{String,Any}()
-
-  for field in fieldnames(typeof(app))
+  ff = collect(fieldnames(typeof(app)))
+  mode == :vue || setdiff!(ff, [:channel__, :modes__], Stipple.AUTOFIELDS)
+  for field in ff
     f = getfield(app, field)
 
     occursin(SETTINGS.private_pattern, String(field)) && continue

--- a/src/stipple/rendering.jl
+++ b/src/stipple/rendering.jl
@@ -160,11 +160,11 @@ function Stipple.render(app::M; mode::Symbol = :vue)::LittleDict{Symbol,Any} whe
   vue
 end
 
-function get_mixins(::Type{<:ReactiveModel})::Vector{Type{ReactiveModel}}
+function get_mixins(::Type{<:ReactiveModel})::Vector{Type{<:ReactiveModel}}
     Type{ReactiveModel}[]
 end
 
-function get_mixins(app::ReactiveModel)::Vector{ReactiveModel}
+function get_mixins(app::ReactiveModel)::Vector{Type{<:ReactiveModel}}
   get_mixins(get_abstract_type(typeof(app)))
 end
 


### PR DESCRIPTION
Currently we have no possibility of including vue mixins.

This PR uses the existing rendering methods for ReactiveModels and makes it possible of including named apps as mixins.
The idea is to make it easier to develop reusable Plugins.

A demo is given in the doc string of  the new macro `@mixins`.

```julia
using Stipple, Stipple.ReactiveTools
using StippleUI

@app GreetMixin begin
  @in name = "John Doe"
end

@mounted GreetMixin = "console.log('Just mounted the App including the GreetMixin')"

@methods GreetMixin :greet => "function() { console.log('Hi ' + this.name + '!') }"

@mixins [GreetMixin]

@app begin
  @mixin GreetMixin
  @in s = "Hi"
  @in i = 10
end

ui() = btn("Say Hello", @click("greet"))

@page("/", ui())

up(open_browser = true)
```

@essenciary @PGimenez I made this a draft PR to discuss whether this implementation is sufficient or how we could develop this further.

- Currently, I don't have a clear idea how to support pre- / postfixes that we support with the `@mixin`, we would need to define js_methods, etc with optional kwargs pre and post, I suppose.
- currently, it is necessary to add the mixins at two places. We could modify the `@mixin` macro to call `@mixins`. This will currently not work properly without supporting post and prefixes, at least, if the mixins are used like `@mixin hh::MyMixin` because that calls `@mixin` with a prefix. 
- Currently the handlers are not ported
