### PR TITLE
Pretty printing and protection of new field :channel_

### DIFF
--- a/src/ReactiveTools.jl
+++ b/src/ReactiveTools.jl
@@ -836,7 +836,7 @@ function get_known_vars(M::Module)
   reactive_vars = Symbol[]
   non_reactive_vars = Symbol[]
   for (k, v) in REACTIVE_STORAGE[M]
-    k in [:channel__, :modes__] && continue
+    k in INTERNALFIELDS && continue
     is_reactive = startswith(string(Stipple.split_expr(v)[2]), r"(Stipple\.)?R(eactive)?($|{)")
     push!(is_reactive ? reactive_vars : non_reactive_vars, k)
   end
@@ -848,7 +848,7 @@ function get_known_vars(::Type{M}) where M<:ReactiveModel
   reactive_vars = Symbol[]
   non_reactive_vars = Symbol[]
   for (k, v) in zip(fieldnames(CM), fieldtypes(CM))
-    k in [:channel__, :modes__] && continue
+    k in INTERNALFIELDS && continue
     push!(v <: Reactive ? reactive_vars : non_reactive_vars, k)
   end
   reactive_vars, non_reactive_vars

--- a/src/Stipple.jl
+++ b/src/Stipple.jl
@@ -402,12 +402,11 @@ function init_storage()
   ch = channelfactory()
 
   LittleDict{Symbol, Expr}(
-    CHANNELFIELDNAME =>
-      :($(Stipple.CHANNELFIELDNAME)::$(Stipple.ChannelName) = $ch),
+    :channel_ => :(channel_::String = $ch),
+    CHANNELFIELDNAME => :($(Stipple.CHANNELFIELDNAME)::$(Stipple.ChannelName) = $ch),
     :modes__ => :(modes__::Stipple.LittleDict{Symbol,Int} = Stipple.LittleDict{Symbol,Int}()),
     :isready => :(isready::Stipple.R{Bool} = false),
-    :isprocessing => :(isprocessing::Stipple.R{Bool} = false),
-    :channel_ => :(channel_::String = $ch),
+    :isprocessing => :(isprocessing::Stipple.R{Bool} = (false, READONLY)),
     :fileuploads => :(fileuploads::Stipple.R{Dict{AbstractString,AbstractString}} = Dict{AbstractString,AbstractString}())
   )
 end

--- a/src/Stipple.jl
+++ b/src/Stipple.jl
@@ -96,6 +96,7 @@ include("stipple/json.jl")
 include("stipple/undefined.jl")
 include("stipple/assets.jl")
 include("stipple/converters.jl")
+include("stipple/print.jl")
 
 using .NamedTuples
 

--- a/src/Stipple.jl
+++ b/src/Stipple.jl
@@ -1145,7 +1145,7 @@ macro mixin_old(expr, prefix = "", postfix = "")
   values = getfield.(Ref(mix), fnames)
   output = quote end
   for (f, type, v) in zip(Symbol.(pre, fnames, post), fieldtypes(get_concrete_type(T)), values)
-    f in Symbol.(prefix, [:channel__, :modes__, AUTOFIELDS...], postfix) && continue
+    f in Symbol.(prefix, vcat(INTERNALFIELDS, AUTOFIELDS), postfix) && continue
     v_copy = Stipple._deepcopy(v)
     push!(output.args, v isa Symbol ? :($f::$type = $(QuoteNode(v))) : :($f::$type = $v_copy))
   end

--- a/src/stipple/print.jl
+++ b/src/stipple/print.jl
@@ -14,7 +14,11 @@ function print_object(io, obj::T, omit = nothing, compact = false) where T <: Re
     omit !== nothing && setdiff!(fields, omit)
     internal_or_auto = true
 
-    println(io, "Instance of '" * match(r"^#*([^!]+)", String(T.name.name)).captures[1] * "'")
+    app = match(r"^#*([^!]+)", String(T.name.name)).captures[1]
+    if app == "Main_ReactiveModel" && parentmodule(T) != Main
+        app = String(nameof(parentmodule(T)))
+    end
+    println(io, "Instance of '$app'")
     for fieldname in fields
         field = getproperty(obj, fieldname)
         fieldmode = isprivate(fieldname, obj) ? "private" : isreadonly(fieldname, obj) ? "out" : "in"

--- a/src/stipple/print.jl
+++ b/src/stipple/print.jl
@@ -1,0 +1,57 @@
+function print_object(io, obj::T, omit = nothing, compact = false) where T
+    # currently no different printing for compact = true ...
+    fields = [p for p in propertynames(obj)]
+    omit !== nothing && setdiff!(fields, omit)
+
+    println(io, match(r"^#*([^!]+)", String(T.name.name)).captures[1])
+    for field in fields
+        println(io, "    $field: ", Observables.to_value(getproperty(obj, field)))
+    end
+end
+
+function print_object(io, obj::T, omit = nothing, compact = false) where T <: ReactiveModel
+    fields = [p for p in propertynames(obj)]
+    omit !== nothing && setdiff!(fields, omit)
+    internal_or_auto = true
+
+    println(io, "Instance of '" * match(r"^#*([^!]+)", String(T.name.name)).captures[1] * "'")
+    for fieldname in fields
+        field = getproperty(obj, fieldname)
+        fieldmode = isprivate(fieldname, obj) ? "private" : isreadonly(fieldname, obj) ? "out" : "in"
+        fieldtype = if field isa Reactive
+            if fieldname in AUTOFIELDS
+                "autofield, $fieldmode"
+            else
+                if internal_or_auto
+                    println(io)
+                    internal_or_auto = false
+                end
+                fieldmode
+            end
+        else
+            if fieldname in INTERNALFIELDS
+                "internal"
+            else
+                if internal_or_auto
+                    println(io)
+                    internal_or_auto = false
+                end
+                "$fieldmode, non-reactive"
+            end
+        end
+
+        println(io, "    $fieldname ($fieldtype): ", Observables.to_value(field))
+    end
+end
+
+# default show used by Array show
+function Base.show(io::IO, obj::ReactiveModel)
+    compact = get(io, :compact, true)
+    print_object(io, obj, compact)
+end
+
+# default show used by display() on the REPL
+function Base.show(io::IO, mime::MIME"text/plain", obj::ReactiveModel)
+    compact = get(io, :compact, false)
+    print_object(io, obj, compact)
+end

--- a/src/stipple/reactive_props.jl
+++ b/src/stipple/reactive_props.jl
@@ -4,7 +4,7 @@
 isprivate(field::Reactive) = field.r_mode == PRIVATE
 
 function isprivate(fieldname::Symbol, model::M)::Bool where {M<:ReactiveModel}
-  fieldname in [Stipple.CHANNELFIELDNAME, :modes__] && return true
+  fieldname in INTERNALFIELDS && return true
 
   field = getfield(model, fieldname)
   field isa Reactive ? isprivate(field) : get(model.modes__, fieldname, 0) == PRIVATE


### PR DESCRIPTION
1. The newly created field `:channel_` is currently not protected and distributed to the client
    - a new `const INTERNALFIELDS = [:channel_, :channel__, :modes__]` is created in order to make protection of internal fields easier
    - protection is now based on INTERNALFIELDS, not on a manual listing
2. model printing is currently not easy to understand ath the REPL, Garish.pprint doesn't improve the situation a lot
    - prettyprinting for the REPL has been implemented
```julia
julia> @app begin
         @out non_reactive a_::Int = 12
         @out s_ = "Hello"
         @out f = jsfunction"console.log('Hi')"
       end
__GF_AUTO_HANDLERS__ (generic function with 1 method)

julia> @init
Instance of 'Main_ReactiveModel'
    channel_ (internal): JUURVSVWBPYQFUNBDYIEDYVCFGCTUEFG
    channel__ (internal): JUURVSVWBPYQFUNBDYIEDYVCFGCTUEFG
    modes__ (internal): LittleDict(:a_ => 4)
    isready (autofield, in): false
    isprocessing (autofield, out): false
    fileuploads (autofield, in): Dict{AbstractString, AbstractString}()

    a_ (out, non-reactive): 12
    s_ (out): Hello
    f (out): Dict{Symbol, Any}(:jsfunction => Dict{Symbol, Any}(:body => "console.log('Hi')", :arguments => ""))
```
