### PR TITLE
more options for head_content

### DIFF
--- a/src/Layout.jl
+++ b/src/Layout.jl
@@ -39,7 +39,7 @@ julia> layout([
 ```
 """
 function layout(output::Union{S,Vector}, m::M;
-                partial::Bool = false, title::String = "", class::String = "", style::String = "", head_content::String = "",
+                partial::Bool = false, title::String = "", class::String = "", style::String = "", head_content::Union{AbstractString, Vector{<:AbstractString}} = "",
                 channel::String = Stipple.channel_js_name,
                 core_theme::Bool = true)::ParsedHTMLString where {M<:ReactiveModel, S<:AbstractString}
 
@@ -58,7 +58,7 @@ function layout(output::Union{S,Vector}, m::M;
       Genie.Renderer.Html.head([
         Genie.Renderer.Html.title(title)
         Genie.Renderer.Html.meta(name="viewport", content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no")
-        head_content
+        join(head_content)
       ])
       Genie.Renderer.Html.body(content, class=class, style=style)
     ])
@@ -83,7 +83,7 @@ julia> page(:elemid, [
 """
 function page(model::M, args...;
               partial::Bool = false, title::String = "", class::String = "container", style::String = "",
-              channel::String = Genie.config.webchannels_default_route, head_content::String = "",
+              channel::String = Genie.config.webchannels_default_route, head_content::Union{AbstractString, Vector{<:AbstractString}} = "",
               prepend::Union{S,Vector} = "", append::Union{T,Vector} = [],
               core_theme::Bool = true, kwargs...)::ParsedHTMLString where {M<:Stipple.ReactiveModel, S<:AbstractString,T<:AbstractString}
 

--- a/src/ReactiveTools.jl
+++ b/src/ReactiveTools.jl
@@ -39,7 +39,7 @@ const TYPES = LittleDict{Module,Union{<:DataType,Nothing}}()
 const HANDLERS_FUNCTIONS = LittleDict{Type{<:ReactiveModel},Function}()
 
 function DEFAULT_LAYOUT(; title::String = "Genie App",
-                          meta::D = Dict()) where {D <:AbstractDict}
+                          meta::D = Dict(), head_content::Union{AbstractString, Vector} = "") where {D <:AbstractDict}
   tags = Genie.Renderers.Html.for_each(x -> """<meta name="$(string(x.first))" content="$(string(x.second))">\n""", meta)
   """
 <!DOCTYPE html>
@@ -64,6 +64,7 @@ function DEFAULT_LAYOUT(; title::String = "Genie App",
       }
       ._genie .row .col-12 { width:50%;margin:auto; }
     </style>
+    $(join(head_content, "\n    "))
   </head>
   <body>
     <div class='container'>


### PR DESCRIPTION
This PR has two parts:
- accept AbstractStrings and Vectors for head_content
- accept head_content in DEFAULT_LAYOUT
```julia
cesium_head = [
  script(src = "https://cesium.com/downloads/cesiumjs/releases/1.113/Build/Cesium/Cesium.js", ),
  link(href = "https://cesium.com/downloads/cesiumjs/releases/1.113/Build/Cesium/Widgets/widgets.css", rel = "stylesheet", )
]

route("/") do
    page(@init, ui, head_content = cesium_head)
end

# or alternatively

@page("/", ui, Stipple.ReactiveTools.DEFAULT_LAYOUT(head_content = cesium_head))
```

Note: for the latter version to work, you have to delay a potential init script if it refers to DOM elements until they are visible, typically, when the app is ready. `js_initscript` is a wrapper, that executes code after the webtransport is subscribed.
```julia
cesium_module_text = """
    Cesium.Ion.defaultAccessToken = '$cesium_token';
    const viewer = new Cesium.Viewer('cesiumContainer', {
      terrain: Cesium.Terrain.fromWorldTerrain(),
    });    

    // Fly the camera to San Francisco at the given longitude, latitude, and height.
    viewer.camera.flyTo({
      destination: Cesium.Cartesian3.fromDegrees(-122.4175, 37.655, 400),
      orientation: {
        heading: Cesium.Math.toRadians(0.0),
        pitch: Cesium.Math.toRadians(-15.0),
      }
    });

    // Add Cesium OSM Buildings, a global 3D buildings layer.
    const buildingTileset = await Cesium.createOsmBuildingsAsync();
    viewer.scene.primitives.add(buildingTileset);
"""

cesium_module() = [script(Stipple.js_initscript("""
  newscript = document.createElement('script')
  newscript.text = $(json(cesium_module_text))
  newscript.type = 'module'
  document.head.appendChild(newscript)
"""))]

@deps cesium_module
```