### PR TITLE
add prettyprinting of models

### DIFF
--- a/src/Stipple.jl
+++ b/src/Stipple.jl
@@ -96,6 +96,7 @@ include("stipple/json.jl")
 include("stipple/undefined.jl")
 include("stipple/assets.jl")
 include("stipple/converters.jl")
+include("stipple/print.jl")
 
 using .NamedTuples
 

--- a/src/stipple/print.jl
+++ b/src/stipple/print.jl
@@ -14,7 +14,11 @@ function print_object(io, obj::T, omit = nothing, compact = false) where T <: Re
     omit !== nothing && setdiff!(fields, omit)
     internal_or_auto = true
 
-    println(io, "Instance of '" * match(r"^#*([^!]+)", String(T.name.name)).captures[1] * "'")
+    app = match(r"^#*([^!]+)", String(T.name.name)).captures[1]
+    if app == "Main_ReactiveModel" && parentmodule(T) != Main
+        app = String(nameof(parentmodule(T)))
+    end
+    println(io, "Instance of '$app'")
     for fieldname in fields
         field = getproperty(obj, fieldname)
         fieldmode = isprivate(fieldname, obj) ? "private" : isreadonly(fieldname, obj) ? "out" : "in"

--- a/src/stipple/print.jl
+++ b/src/stipple/print.jl
@@ -1,0 +1,57 @@
+function print_object(io, obj::T, omit = nothing, compact = false) where T
+    # currently no different printing for compact = true ...
+    fields = [p for p in propertynames(obj)]
+    omit !== nothing && setdiff!(fields, omit)
+
+    println(io, match(r"^#*([^!]+)", String(T.name.name)).captures[1])
+    for field in fields
+        println(io, "    $field: ", Observables.to_value(getproperty(obj, field)))
+    end
+end
+
+function print_object(io, obj::T, omit = nothing, compact = false) where T <: ReactiveModel
+    fields = [p for p in propertynames(obj)]
+    omit !== nothing && setdiff!(fields, omit)
+    internal_or_auto = true
+
+    println(io, "Instance of '" * match(r"^#*([^!]+)", String(T.name.name)).captures[1] * "'")
+    for fieldname in fields
+        field = getproperty(obj, fieldname)
+        fieldmode = isprivate(fieldname, obj) ? "private" : isreadonly(fieldname, obj) ? "out" : "in"
+        fieldtype = if field isa Reactive
+            if fieldname in AUTOFIELDS
+                "autofield, $fieldmode"
+            else
+                if internal_or_auto
+                    println(io)
+                    internal_or_auto = false
+                end
+                fieldmode
+            end
+        else
+            if fieldname in INTERNALFIELDS
+                "internal"
+            else
+                if internal_or_auto
+                    println(io)
+                    internal_or_auto = false
+                end
+                "$fieldmode, non-reactive"
+            end
+        end
+
+        println(io, "    $fieldname ($fieldtype): ", Observables.to_value(field))
+    end
+end
+
+# default show used by Array show
+function Base.show(io::IO, obj::ReactiveModel)
+    compact = get(io, :compact, true)
+    print_object(io, obj, compact)
+end
+
+# default show used by display() on the REPL
+function Base.show(io::IO, mime::MIME"text/plain", obj::ReactiveModel)
+    compact = get(io, :compact, false)
+    print_object(io, obj, compact)
+end


### PR DESCRIPTION
model printing is currently not easy to understand at the REPL, Garish.pprint doesn't improve the situation a lot
This PR implements automatic prettyprinting at the REPL:
```julia
julia> @app begin
         @out non_reactive a_::Int = 12
         @out s_ = "Hello"
         @out f = jsfunction"console.log('Hi')"
       end
__GF_AUTO_HANDLERS__ (generic function with 1 method)

julia> @init
Instance of 'Main_ReactiveModel'
    channel_ (internal): JUURVSVWBPYQFUNBDYIEDYVCFGCTUEFG
    channel__ (internal): JUURVSVWBPYQFUNBDYIEDYVCFGCTUEFG
    modes__ (internal): LittleDict(:a_ => 4)
    isready (autofield, in): false
    isprocessing (autofield, out): false
    fileuploads (autofield, in): Dict{AbstractString, AbstractString}()

    a_ (out, non-reactive): 12
    s_ (out): Hello
    f (out): Dict{Symbol, Any}(:jsfunction => Dict{Symbol, Any}(:body => "console.log('Hi')", :arguments => ""))
```