### PR TITLE
add field-specific debouncing

### DIFF
--- a/src/ReactiveTools.jl
+++ b/src/ReactiveTools.jl
@@ -290,7 +290,12 @@ end
 
     @debounce App fieldname ms
 
-Set field-specific debounce time in ms
+Set field-specific debounce time in ms.
+### Parameters
+
+- `APP`: a subtype of ReactiveModel, e.g. `MyApp`
+- `fieldname`: fieldname òr fieldnames as written in the declaration, e.g. `x`, `(x, y, z)`
+- `ms`: debounce time in ms
 
 ### Example
 #### Implicit apps
@@ -305,7 +310,7 @@ end
 @debounce quick 0
 
 # long debouncing for long-running tasks
-@debounce slow 1000
+@debounce (slow1, slow2) 1000
 ```
 #### Explicit apps
 

--- a/src/Stipple.jl
+++ b/src/Stipple.jl
@@ -115,6 +115,40 @@ const PURGE_TIME_LIMIT = Ref{Period}(Day(1))
 const PURGE_NUMBER_LIMIT = Ref(1000)
 const PURGE_CHECK_DELAY = Ref(60)
 
+const DEBOUNCE = LittleDict{Type{<:ReactiveModel}, LittleDict{Symbol, Any}}()
+
+"""
+    debounce(M::Type{<:ReactiveModel}, fieldnames::Union{Symbol, Vector{Symbol}}, debounce::Union{Int, Nothing} = nothing)
+
+Add field-specific debounce times.
+"""
+function debounce(M::Type{<:ReactiveModel}, fieldnames::Union{Symbol, Vector{Symbol}, NTuple{N, Symbol} where N}, debounce::Union{Int, Nothing} = nothing)
+  if debounce === nothing
+    haskey(DEBOUNCE, M) || return
+    d = DEBOUNCE[M]
+    if fieldnames isa Symbol
+      delete!(d, fieldnames)
+    else
+      for v in fieldnames
+        delete!(d, v)
+      end
+    end
+    isempty(d) && delete!(DEBOUNCE, M)
+  else
+    d = get!(LittleDict{Symbol, Any}, DEBOUNCE, M)
+    if fieldnames isa Symbol
+      d[fieldnames] = debounce
+    else
+      for v in fieldnames
+        d[v] = debounce
+      end
+    end
+  end
+  return
+end
+
+debounce(M::Type{<:ReactiveModel}, ::Nothing) = delete!(DEBOUNCE, M)
+
 """
 `function sorted_channels()`
 
@@ -302,20 +336,29 @@ function watch(vue_app_name::String, fieldname::Symbol, channel::String, debounc
   isempty(jsfunction) &&
     (jsfunction = "Genie.WebChannels.sendMessageTo($js_channel, 'watchers', {'payload': {'field':'$fieldname', 'newval': newVal, 'oldval': oldVal, 'sesstoken': document.querySelector(\"meta[name='sesstoken']\")?.getAttribute('content')}});")
 
+  output = IOBuffer()
   if fieldname == :isready
-    output = """
+    print(output, """
       $vue_app_name.\$watch(function(){return this.$fieldname}, function(newVal, oldVal){$jsfunction}, {deep: true});
-    """
+    """)
   else
-    output = """
-      $vue_app_name.\$watch(function(){return this.$fieldname}, _.debounce(function(newVal, oldVal){$jsfunction}, $debounce), {deep: true});
-    """
+    AM = get_abstract_type(M)
+    debounce = get(get(DEBOUNCE, AM, Dict{Symbol, Any}()), fieldname, debounce)
+    print(output, debounce == 0 ?
+      """
+        $vue_app_name.\$watch(function(){return this.$fieldname}, function(newVal, oldVal){$jsfunction}, {deep: true});
+      """ : 
+      """
+        $vue_app_name.\$watch(function(){return this.$fieldname}, _.debounce(function(newVal, oldVal){$jsfunction}, $debounce), {deep: true});
+      """
+    )
   end
   # in production mode vue does not fill `this.expression` in the watcher, so we do it manually
   Genie.Configuration.isprod() &&
-    (output *= "$vue_app_name._watchers[$vue_app_name._watchers.length - 1].expression = 'function(){return this.$fieldname}'")
+    print(output, "$vue_app_name._watchers[$vue_app_name._watchers.length - 1].expression = 'function(){return this.$fieldname}'")
 
-  output *= "\n\n"
+  print(output, "\n\n")
+  String(take!(output))
 end
 
 #===#

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -118,6 +118,13 @@ end
     # check reactivity
     @eval model.i[] = 20
     @test model.s[] == "20"
+
+    @eval @debounce TestApp i 101
+    @eval @debounce TestApp (a, b, c) 101
+    @test Stipple.DEBOUNCE[TestApp][:i] == 101
+    
+    @eval @clear_debounce TestApp
+    @test haskey(Stipple.DEBOUNCE, TestApp) == false
 end
 
 @testset "Reactive API (implicit)" begin
@@ -142,6 +149,14 @@ end
     # check reactivity
     @eval model.i2[] = 20
     @test model.s2[] == "20"
+
+    # check field-specific debouncing
+    @eval @debounce i3 101
+    @eval @debounce (a, b, c) 101
+    @test Stipple.DEBOUNCE[Stipple.@type()][:i3] == 101
+    
+    @eval @clear_debounce
+    @test haskey(Stipple.DEBOUNCE, Stipple.@type()) == false
 end
 
 @testset "Reactive API (implicit) with mixins and handlers" begin


### PR DESCRIPTION
This PR address #186 and adds the possibility of adding field-specific debounce times via

```julia
# set a debounce time of 10 ms
@debounce myfield 10

# set a debounce time of 10 ms for an explicit app
@debounce MyApp myfield 10

# remove the field-specific debounce time for the field `myfield`
@clear_debounce myfield

# remove the field-specific debounce time for a field of an explicit App
@clear_debounce MyApp myfield

# remove all field-specific debounce times
@clear_debounce 

# remove all field-specific debounce times from `MyApp`
@clear_debounce MyApp


# In the good old function way ...

# set a debounce time of 10 ms
Stipple.debounce(MyApp, :myfield, 10)

# remove the debounce time
Stipple.debounce(MyApp, :myfield, nothing)

```
tests and docstrings are provided