### PR TITLE
fix diverging models in watcher and event channels

### DIFF
--- a/src/Stipple.jl
+++ b/src/Stipple.jl
@@ -619,27 +619,25 @@ function init(t::Type{M};
     end
 
     ch = "/$channel/events"
-    if ! Genie.Router.ischannel(Router.channelname(ch))
-      Genie.Router.channel(ch, named = Router.channelname(ch)) do
-        # get event name
-        event = Genie.Requests.payload(:payload)["event"]
-        # form handler parameter & call event notifier
-        handler = Symbol(get(event, "name", nothing))
-        event_info = get(event, "event", nothing)
+    Genie.Router.channel(ch, named = Router.channelname(ch)) do
+      # get event name
+      event = Genie.Requests.payload(:payload)["event"]
+      # form handler parameter & call event notifier
+      handler = Symbol(get(event, "name", nothing))
+      event_info = get(event, "event", nothing)
 
-        # add client id if requested
-        if event_info isa Dict && get(event_info, "_addclient", false)
-          client = transport == Genie.WebChannels ? Genie.WebChannels.id(Genie.Requests.wsclient()) : Genie.Requests.wtclient()
-          push!(event_info, "_client" => client)
-        end
-
-        isempty(methods(notify, (M, Val{handler}))) || notify(model, Val(handler))
-        isempty(methods(notify, (M, Val{handler}, Any))) || notify(model, Val(handler), event_info)
-
-        LAST_ACTIVITY[Symbol(channel)] = now()
-
-        ok_response
+      # add client id if requested
+      if event_info isa Dict && get(event_info, "_addclient", false)
+        client = transport == Genie.WebChannels ? Genie.WebChannels.id(Genie.Requests.wsclient()) : Genie.Requests.wtclient()
+        push!(event_info, "_client" => client)
       end
+
+      isempty(methods(notify, (M, Val{handler}))) || notify(model, Val(handler))
+      isempty(methods(notify, (M, Val{handler}, Any))) || notify(model, Val(handler), event_info)
+
+      LAST_ACTIVITY[Symbol(channel)] = now()
+
+      ok_response
     end
   end
 


### PR DESCRIPTION
The setup in Stipple is such that each client receives its own model and that model is connected via a channel. But different clients that use the same channel don't really use different models. Instead they are using only the latest model they write to and that they receive data from. The respective part of code is here.

(https://github.com/GenieFramework/Stipple.jl/blob/master/src/Stipple.jl#L533).

However, the event channel is not always updated to use the latest model due to the [following condition](https://github.com/GenieFramework/Stipple.jl/blob/master/src/Stipple.jl#L622) 
```julia
if ! Genie.Router.ischannel(Router.channelname(ch))
```
Unfortunately, this is not only critical for multi-clients but also in case of page reloading.
After reloading the page the watchers act on the latest model, while events still act on an old model that does not receive the data updates. So the results are getting incoherent and unpredictable.

I propose to remove the condition to get rid of this problem.