### PR TITLE
stipple_parse structs

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -579,7 +579,7 @@ end
     end
     
     t2 = T2(1, T1(2, 3))
-    t2_dict = JSON3.read(json(t2), Dict)
+    t2_dict = JSON3.read(Stipple.json(t2), Dict)
     
     Base.@kwdef struct T3
         c::Int = 1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -566,3 +566,32 @@ end
     remove_css(my_css, byname = true)
     @test findfirst(==(my_css), Stipple.Layout.THEMES[]) === nothing
 end
+
+@testset "parsing" begin
+    struct T1
+        c::Int
+        d::Int
+    end
+    
+    struct T2
+        a::Int
+        b::T1
+    end
+    
+    t2 = T2(1, T1(2, 3))
+    t2_dict = JSON3.read(json(t2), Dict)
+    
+    Base.@kwdef struct T3
+        c::Int = 1
+        d::Int = 3
+    end
+    
+    Base.@kwdef struct T4
+        a::Int = 1
+        b::T3 = T3()
+    end
+    
+    @test Stipple.stipple_parse(T2, t2_dict) == T2(1, T1(2, 3))
+    @test Stipple.stipple_parse(T3, Dict()) == T3(1, 3)
+    @test Stipple.stipple_parse(T4, Dict()) == T4(1, T3(1, 3))
+end


### PR DESCRIPTION
Add automatic struct parsing for both normal structs and structs defined by `@kwdef`:
```julia
struct HH1
  c::Int
  d::Int
end

struct HH2
  a::Int
  b::HH1
end

hh2 = HH2(1, HH1(2, 3))
hh2_dict = JSON3.read(json(hh2), Dict)

Base.@kwdef struct T1
  c::Int = 1
  d::Int = 3
end

Base.@kwdef struct T2
  a::Int = 1
  b::T1 = T1()
end

Stipple.stipple_parse(HH2, hh2_dict)
# HH2(1, HH1(2, 3))

Stipple.stipple_parse(T1, Dict())
# T1(1, 3)

Stipple.stipple_parse(T2, Dict())
# T2(1, T1(1, 3))
```
