### PR TITLE
remove julia_to_vue, make OptDict an OrderedDict

### DIFF
--- a/src/stipple/rendering.jl
+++ b/src/stipple/rendering.jl
@@ -130,7 +130,7 @@ jsrender(r::Reactive, args...) = jsrender(getfield(getfield(r,:o), :val), args..
 Renders the Julia `ReactiveModel` `app` as the corresponding Vue.js JavaScript code.
 """
 function Stipple.render(app::M)::Dict{Symbol,Any} where {M<:ReactiveModel}
-  result = Dict{String,Any}()
+  result = OptDict()
 
   for field in fieldnames(typeof(app))
     f = getfield(app, field)
@@ -138,7 +138,7 @@ function Stipple.render(app::M)::Dict{Symbol,Any} where {M<:ReactiveModel}
     occursin(SETTINGS.private_pattern, String(field)) && continue
     f isa Reactive && f.r_mode == PRIVATE && continue
 
-    result[julia_to_vue(field)] = Stipple.jsrender(f, field)
+    result[field] = Stipple.jsrender(f, field)
   end
 
   vue = Dict( :el => JSONText("rootSelector"),


### PR DESCRIPTION
removing `julia_to_vue()` fixes #275 
making the OptDict an OrderedDict keeps the ordering of attributes, which is definitely a good thing and which removes the necessity to define another attributes function in StipplePlotly, where ordering was required.