### PR TITLE
never add core_theme to THEMES

### DIFF
--- a/src/Layout.jl
+++ b/src/Layout.jl
@@ -507,6 +507,11 @@ function htmldiv(args...;
   Genie.Renderer.Html.div(args...; kwargs...)
 end
 
+function coretheme()
+    stylesheet("https://fonts.googleapis.com/css?family=Material+Icons"),
+    stylesheet(Genie.Assets.asset_path(Stipple.assets_config, :css, file="stipplecore"))
+end
+
 """
     function theme() :: String
 
@@ -528,20 +533,12 @@ julia> push!(Stipple.Layout.THEMES[], StippleUI.theme)
 function theme(; core_theme::Bool = true) :: Vector{String}
   output = String[]
 
-  if core_theme
-    push!(THEMES[], () -> begin
-        stylesheet("https://fonts.googleapis.com/css?family=Material+Icons"),
-        stylesheet(Genie.Assets.asset_path(Stipple.assets_config, :css, file="stipplecore"))
-      end
-    )
-  end
-
-  unique!(THEMES[])
-
   for f in THEMES[]
     push!(output, f()...)
   end
 
+  core_theme && coretheme ∉ THEMES[] && push!(output, coretheme()...)
+  
   output
 end
 

--- a/src/Layout.jl
+++ b/src/Layout.jl
@@ -10,7 +10,8 @@ using Genie, Stipple
 export layout, add_css, remove_css
 export page, app, row, column, cell, container, flexgrid_kwargs, htmldiv, @gutter
 
-export theme
+export theme, googlefonts_css, stipplecore_css, genie_footer
+
 const THEMES = Ref(Function[])
 
 const FLEXGRID_KWARGS = [:col, :xs, :sm, :md, :lg, :xl, :gutter, :xgutter, :ygutter]
@@ -120,6 +121,31 @@ end
 
 function iscontainer(class)
     false
+end
+
+function genie_footer()
+  ParsedHTMLString("""
+  <style>
+    ._genie_logo {
+      background:url('https://genieframework.com/logos/genie/logo-simple-with-padding.svg') no-repeat;
+      background-size:40px;
+      padding-top:22px;
+      padding-right:10px;
+      color:transparent !important;
+      font-size:9pt;
+    }
+    ._genie .row .col-12 { width:50%; margin:auto; }
+  </style>
+  <footer class='_genie container'>
+    <div class='row'>
+      <div class='col-12'>
+        <p class='text-muted credit' style='text-align:center;color:#8d99ae;'>Built with
+          <a href='https://genieframework.com' target='_blank' class='_genie_logo' ref='nofollow'>Genie</a>
+        </p>
+      </div>
+    </div>
+  </footer>
+  """)
 end
 
 function flexgrid_class(tag::Symbol, value::Union{String,Int,Nothing,Symbol} = -1, container = false)
@@ -507,6 +533,14 @@ function htmldiv(args...;
   Genie.Renderer.Html.div(args...; kwargs...)
 end
 
+function googlefonts_css()
+  (stylesheet("https://fonts.googleapis.com/css?family=Material+Icons"),)
+end
+
+function stipplecore_css()
+  (stylesheet(Genie.Assets.asset_path(Stipple.assets_config, :css, file="stipplecore")),)
+end
+
 function coretheme()
     stylesheet("https://fonts.googleapis.com/css?family=Material+Icons"),
     stylesheet(Genie.Assets.asset_path(Stipple.assets_config, :css, file="stipplecore"))
@@ -533,11 +567,11 @@ julia> push!(Stipple.Layout.THEMES[], StippleUI.theme)
 function theme(; core_theme::Bool = true) :: Vector{String}
   output = String[]
 
+  core_theme && coretheme ∉ THEMES[] && push!(output, coretheme()...)
+
   for f in THEMES[]
     push!(output, f()...)
   end
-
-  core_theme && coretheme ∉ THEMES[] && push!(output, coretheme()...)
   
   output
 end

--- a/src/ReactiveTools.jl
+++ b/src/ReactiveTools.jl
@@ -42,7 +42,9 @@ const TYPES = LittleDict{Module,Union{<:DataType,Nothing}}()
 const HANDLERS_FUNCTIONS = LittleDict{Type{<:ReactiveModel},Function}()
 
 function DEFAULT_LAYOUT(; title::String = "Genie App",
-                          meta::D = Dict(), head_content::Union{AbstractString, Vector} = "") where {D <:AbstractDict}
+                          meta::D = Dict(),
+                          head_content::Union{AbstractString, Vector} = "",
+                          core_theme::Bool = true) where {D <:AbstractDict}
   tags = Genie.Renderers.Html.for_each(x -> """<meta name="$(string(x.first))" content="$(string(x.second))">\n""", meta)
   """
 <!DOCTYPE html>
@@ -73,7 +75,7 @@ function DEFAULT_LAYOUT(; title::String = "Genie App",
     <div class='container'>
       <div class='row'>
         <div class='col-12'>
-          <% Stipple.page(model, partial = true, v__cloak = true, [Stipple.Genie.Renderer.Html.@yield], Stipple.@if(:isready)) %>
+          <% Stipple.page(model, partial = true, v__cloak = true, [Stipple.Genie.Renderer.Html.@yield], Stipple.@if(:isready); core_theme = $core_theme) %>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Currently, when `theme()` is called once, the coretheme is added to `THEMES[]`.

This is a bit unfortunate, because you first have to remove it manually if you want to render a page without core_theme. Moreover, parallel pages with and without core_theme are difficult to maintain. As theme() is anyhow called in order to append all stylesheets to the page, we can rely on the keyword attribute. Currently it's always added and then removed by `unique!()` if it was present before. Moreover, I made it a named function make it more understandable.