### PR TITLE
fix precompilation error, suppress output

### DIFF
--- a/src/Stipple.jl
+++ b/src/Stipple.jl
@@ -1260,6 +1260,9 @@ using Stipple.ReactiveTools
   @compile_workload begin
       # all calls in this block will be precompiled, regardless of whether
       # they belong to your package or not (on Julia 1.8 and higher)
+      # set secret in order to avoid automatic generation of a new one,
+      # which would invalidate the precompiled file
+      Genie.Secrets.secret_token!(repeat("f", 64))
       ui() = [cell("hello"), row("world"), htmldiv("Hello World")]
 
       @app PrecompileApp begin
@@ -1279,16 +1282,18 @@ using Stipple.ReactiveTools
       port === nothing && (port = rand(8081:8999))
 
       Logging.with_logger(Logging.SimpleLogger(stdout, Logging.Error)) do
-      up(port)
-        
-      precompile_get = tryparse(Bool, get(ENV, "STIPPLE_PRECOMPILE_GET", "1"))
-      precompile_get === true && HTTP.get("http://localhost:$port")
-      # The following lines (still) produce an error although
-      # they pass at the repl. Not very important though.
-      # HTTP.get("http://localhost:$port$(Genie.Assets.asset_path(Genie.assets_config, :js, file = "channels"))")
-      # HTTP.get("http://localhost:$port$(Genie.Assets.asset_path(assets_config, :js, file = "stipplecore"))")
-      down()
+        up(port)
+          
+        precompile_get = tryparse(Bool, get(ENV, "STIPPLE_PRECOMPILE_GET", "1"))
+        precompile_get === true && HTTP.get("http://localhost:$port")
+        # The following lines (still) produce an error although
+        # they pass at the repl. Not very important though.
+        # HTTP.get("http://localhost:$port$(Genie.Assets.asset_path(Genie.assets_config, :js, file = "channels"))")
+        # HTTP.get("http://localhost:$port$(Genie.Assets.asset_path(assets_config, :js, file = "stipplecore"))")
+        down()
       end
+      # reset secret back to empty string
+      Genie.Secrets.secret_token!("")
   end
   PRECOMPILE[] = false
 end

--- a/src/Stipple.jl
+++ b/src/Stipple.jl
@@ -1277,6 +1277,8 @@ using Stipple.ReactiveTools
       end
       port = tryparse(Int, get(ENV, "STIPPLE_PRECOMPILE_PORT", ""))
       port === nothing && (port = rand(8081:8999))
+
+      Logging.with_logger(Logging.SimpleLogger(stdout, Logging.Error)) do
       up(port)
         
       precompile_get = tryparse(Bool, get(ENV, "STIPPLE_PRECOMPILE_GET", "1"))
@@ -1286,6 +1288,7 @@ using Stipple.ReactiveTools
       # HTTP.get("http://localhost:$port$(Genie.Assets.asset_path(Genie.assets_config, :js, file = "channels"))")
       # HTTP.get("http://localhost:$port$(Genie.Assets.asset_path(assets_config, :js, file = "stipplecore"))")
       down()
+      end
   end
   PRECOMPILE[] = false
 end


### PR DESCRIPTION
Details
- set secret before precompilation and reset afterwards to prevent precompilation error
- suppress server output during precompilation