### PR TITLE
Support multi-model pages

### DIFF
--- a/assets/js/keepalive.js
+++ b/assets/js/keepalive.js
@@ -14,7 +14,7 @@ function keepalive(WebChannel) {
     }
   }
 
-  if (!WebChannel.wsconnectionalert_triggered) {
+  if (!WebChannel.ws_disconnected) {
     if (Genie.Settings.env == 'dev') {
       console.info('Keeping connection alive');
     }

--- a/assets/js/keepalive.js
+++ b/assets/js/keepalive.js
@@ -1,22 +1,32 @@
 /*
-** keepalive.js // v1.0.0 // 6th January 2022
+** keepalive.js // v1.1.0 // 11 November 2024
 ** Keeps alive the websocket connection by sending a ping every x seconds
 ** where x = Genie.config.webchannels_keepalive_frequency
 */
 
 function keepalive(WebChannel) {
   if (WebChannel.lastMessageAt !== undefined) {
-    if (Date.now() - WebChannel.lastMessageAt + 200 < Genie.Settings.webchannels_keepalive_frequency) {
-      return
+    dt = Date.now() - WebChannel.lastMessageAt;
+    // allow for a 200ms buffer
+    if (dt + 200 < Genie.Settings.webchannels_keepalive_frequency) {
+      keepaliveTimer(WebChannel, Genie.Settings.webchannels_keepalive_frequency - dt);
+      return;
     }
   }
 
   if (Genie.Settings.env == 'dev') {
     console.info('Keeping connection alive');
-    console.log(WebChannel.parent.i)
   }
 
   WebChannel.sendMessageTo(WebChannel.channel, 'keepalive', {
     'payload': {}
   });
+}
+
+function keepaliveTimer(WebChannel, startDelay = Genie.Settings.webchannels_keepalive_frequency) {
+  clearInterval(WebChannel.keepalive_interval);
+  setTimeout(() => {
+    keepalive(WebChannel);
+    WebChannel.keepalive_interval = setInterval(() => keepalive(WebChannel), Genie.Settings.webchannels_keepalive_frequency);
+  }, startDelay)
 }

--- a/assets/js/keepalive.js
+++ b/assets/js/keepalive.js
@@ -4,18 +4,19 @@
 ** where x = Genie.config.webchannels_keepalive_frequency
 */
 
-function keepalive() {
-  if (window._lastMessageAt !== undefined) {
-    if (Date.now() - window._lastMessageAt < Genie.Settings.webchannels_keepalive_frequency) {
+function keepalive(WebChannel) {
+  if (WebChannel.lastMessageAt !== undefined) {
+    if (Date.now() - WebChannel.lastMessageAt + 200 < Genie.Settings.webchannels_keepalive_frequency) {
       return
     }
   }
 
   if (Genie.Settings.env == 'dev') {
     console.info('Keeping connection alive');
+    console.log(WebChannel.parent.i)
   }
 
-  Genie.WebChannels.sendMessageTo(CHANNEL, 'keepalive', {
+  WebChannel.sendMessageTo(WebChannel.channel, 'keepalive', {
     'payload': {}
   });
 }

--- a/assets/js/keepalive.js
+++ b/assets/js/keepalive.js
@@ -14,13 +14,14 @@ function keepalive(WebChannel) {
     }
   }
 
-  if (Genie.Settings.env == 'dev') {
-    console.info('Keeping connection alive');
+  if (!WebChannel.wsconnectionalert_triggered) {
+    if (Genie.Settings.env == 'dev') {
+      console.info('Keeping connection alive');
+    }
+    WebChannel.sendMessageTo(WebChannel.channel, 'keepalive', {
+      'payload': {}
+    });
   }
-
-  WebChannel.sendMessageTo(WebChannel.channel, 'keepalive', {
-    'payload': {}
-  });
 }
 
 function keepaliveTimer(WebChannel, startDelay = Genie.Settings.webchannels_keepalive_frequency) {

--- a/assets/js/watchers.js
+++ b/assets/js/watchers.js
@@ -67,7 +67,7 @@ const watcherMixin = {
     },
 
     push: function (field) {
-      Genie.WebChannels.sendMessageTo(CHANNEL, 'watchers', {'payload': {
+      Genie.WebChannels.sendMessageTo(this.channel_, 'watchers', {'payload': {
           'field': field,
           'newval': this[field],
           'oldval': null,
@@ -110,7 +110,7 @@ const eventMixin = {
       if (event_data === undefined) { event_data = {} }
       console.debug('event: ' + JSON.stringify(event_data) + ":" + event_handler)
       if (mode=='addclient') { event_data._addclient = true}
-      Genie.WebChannels.sendMessageTo(window.CHANNEL, 'events', {
+      Genie.WebChannels.sendMessageTo(this.channel_, 'events', {
           'event': {
               'name': event_handler,
               'event': event_data

--- a/assets/js/watchers.js
+++ b/assets/js/watchers.js
@@ -67,7 +67,7 @@ const watcherMixin = {
     },
 
     push: function (field) {
-      Genie.WebChannels.sendMessageTo(this.channel_, 'watchers', {'payload': {
+      this.WebChannel.sendMessageTo(this.channel_, 'watchers', {'payload': {
           'field': field,
           'newval': this[field],
           'oldval': null,
@@ -110,7 +110,7 @@ const eventMixin = {
       if (event_data === undefined) { event_data = {} }
       console.debug('event: ' + JSON.stringify(event_data) + ":" + event_handler)
       if (mode=='addclient') { event_data._addclient = true}
-      Genie.WebChannels.sendMessageTo(this.channel_, 'events', {
+      this.WebChannel.sendMessageTo(this.channel_, 'events', {
           'event': {
               'name': event_handler,
               'event': event_data

--- a/src/Elements.jl
+++ b/src/Elements.jl
@@ -222,8 +222,7 @@ function vue_integration(::Type{M};
       "
       try {
         if (Genie.Settings.webchannels_keepalive_frequency > 0) {
-          clearInterval(app.WebChannel.keepalive_interval);
-          app.WebChannel.keepalive_interval = setInterval(() => keepalive(app.WebChannel), Genie.Settings.webchannels_keepalive_frequency);
+          keepaliveTimer(app.WebChannel, 0);
         }
       } catch (e) {
         if (Genie.Settings.env === 'dev') {

--- a/src/Elements.jl
+++ b/src/Elements.jl
@@ -177,7 +177,7 @@ function vue_integration(::Type{M};
     });
     $app = window.GENIEMODEL = app.mount(rootSelector);
     window.channelIndex = window.channelIndex || 0;
-    $app.WebChannel = Genie.AllWebChannels[channelIndex];
+    $app.WebChannel = Genie.WebChannels;
     $app.WebChannel.parent = $app;
     $app.channel_ = $app.WebChannel.channel;
 

--- a/src/Elements.jl
+++ b/src/Elements.jl
@@ -222,8 +222,8 @@ function vue_integration(::Type{M};
       "
       try {
         if (Genie.Settings.webchannels_keepalive_frequency > 0) {
-          clearInterval(app.keepalive_interval);
-          app.keepalive_interval = setInterval(keepalive, Genie.Settings.webchannels_keepalive_frequency);
+          clearInterval(app.WebChannel.keepalive_interval);
+          app.WebChannel.keepalive_interval = setInterval(() => keepalive(app.WebChannel), Genie.Settings.webchannels_keepalive_frequency);
         }
       } catch (e) {
         if (Genie.Settings.env === 'dev') {
@@ -239,7 +239,7 @@ function vue_integration(::Type{M};
 
   function create$vue_app_name() {
     window.counter$vue_app_name = window.counter$vue_app_name || 1
-    appName = '$vue_app_name' + ((counter$vue_app_name == 1) ? '' : '_' + window.counter$vue_app_name)
+    const appName = '$vue_app_name' + ((counter$vue_app_name == 1) ? '' : '_' + window.counter$vue_app_name)
     rootSelector = '#$vue_app_name' + ((counter$vue_app_name == 1) ? '' : '-' + window.counter$vue_app_name)
     counter$vue_app_name++
 

--- a/src/Elements.jl
+++ b/src/Elements.jl
@@ -238,12 +238,13 @@ function vue_integration(::Type{M};
   };
 
   function create$vue_app_name() {
-    window.counter$vue_app_name = window.counter$vue_app_name || 0
-    appName = '$vue_app_name' + ((counter$vue_app_name == 0) ? '' : '-' + window.counter$vue_app_name)
+    window.counter$vue_app_name = window.counter$vue_app_name || 1
+    appName = '$vue_app_name' + ((counter$vue_app_name == 1) ? '' : '_' + window.counter$vue_app_name)
+    rootSelector = '#$vue_app_name' + ((counter$vue_app_name == 1) ? '' : '-' + window.counter$vue_app_name)
     counter$vue_app_name++
 
     if ( window.autorun === undefined || window.autorun === true ) {
-      initStipple$vue_app_name(appName, '#' + appName);
+      initStipple$vue_app_name(appName, rootSelector);
       initWatchers$vue_app_name($app);
 
       $app.WebChannel.subscriptionHandlers.push(function(event) {

--- a/src/Elements.jl
+++ b/src/Elements.jl
@@ -159,7 +159,7 @@ function vue_integration(::Type{M};
   string(
     "
 
-  function initStipple$vue_app_name(appName, rootSelector){
+  function initStipple$vue_app_name(appName, rootSelector, channel){
     // components = Stipple.init($( core_theme ? "{theme: '$theme'}" : "" ));
     const app = Vue.createApp($( replace(vue_app, "'$(Stipple.UNDEFINED_PLACEHOLDER)'"=>Stipple.UNDEFINED_VALUE) ))
     /* Object.entries(components).forEach(([key, value]) => {
@@ -177,9 +177,9 @@ function vue_integration(::Type{M};
     });
     $app = window.GENIEMODEL = app.mount(rootSelector);
     window.channelIndex = window.channelIndex || 0;
-    $app.WebChannel = Genie.WebChannels;
+    $app.WebChannel = Genie.initWebChannel(channel);
     $app.WebChannel.parent = $app;
-    $app.channel_ = $app.WebChannel.channel;
+    $app.channel_ = channel;
 
     channelIndex++;
   } // end of initStipple
@@ -216,34 +216,34 @@ function vue_integration(::Type{M};
   }
 
   function app_ready(app) {
-      app.isready = true;
-      Genie.Revivers.addReviver(app.revive_jsfunction);
-      $(transport == Genie.WebChannels &&
-      "
-      try {
-        if (Genie.Settings.webchannels_keepalive_frequency > 0) {
-          keepaliveTimer(app.WebChannel, 0);
-        }
-      } catch (e) {
-        if (Genie.Settings.env === 'dev') {
-          console.error('Error setting WebSocket keepalive interval: ' + e);
-        }
+    if (app.WebChannel == Genie.AllWebChannels[0]) Genie.Revivers.addReviver(app.revive_jsfunction);
+    app.isready = true;
+    $(transport == Genie.WebChannels &&
+    "
+    try {
+      if (Genie.Settings.webchannels_keepalive_frequency > 0) {
+        keepaliveTimer(app.WebChannel, 0);
       }
-      ")
-
+    } catch (e) {
       if (Genie.Settings.env === 'dev') {
-        console.info('App starting');
+        console.error('Error setting WebSocket keepalive interval: ' + e);
       }
+    }
+    ")
+
+    if (Genie.Settings.env === 'dev') {
+      console.info('App starting');
+    }
   };
 
-  function create$vue_app_name() {
+  function create$vue_app_name(channel) {
     window.counter$vue_app_name = window.counter$vue_app_name || 1
     const appName = '$vue_app_name' + ((counter$vue_app_name == 1) ? '' : '_' + window.counter$vue_app_name)
     rootSelector = '#$vue_app_name' + ((counter$vue_app_name == 1) ? '' : '-' + window.counter$vue_app_name)
     counter$vue_app_name++
 
     if ( window.autorun === undefined || window.autorun === true ) {
-      initStipple$vue_app_name(appName, rootSelector);
+      initStipple$vue_app_name(appName, rootSelector, channel);
       initWatchers$vue_app_name($app);
 
       $app.WebChannel.subscriptionHandlers.push(function(event) {

--- a/src/Elements.jl
+++ b/src/Elements.jl
@@ -176,6 +176,10 @@ function vue_integration(::Type{M};
       app.config.globalProperties[key] = value
     });
     window.$vue_app_name = window.GENIEMODEL = app.mount(rootSelector);
+    window.channelIndex = window.channelIndex || 0;
+    $vue_app_name.WebChannel = Genie.AllWebChannels[channelIndex];
+    $vue_app_name.channel_ = $vue_app_name.WebChannel.channel;
+    channelIndex++;
   } // end of initStipple
 
     "
@@ -209,8 +213,7 @@ function vue_integration(::Type{M};
     }
   }
 
-  function app_ready() {
-      $vue_app_name.channel_ = window.CHANNEL;
+  function app_$(vue_app_name)_ready() {
       $vue_app_name.isready = true;
       Genie.Revivers.addReviver(window.$(vue_app_name).revive_jsfunction);
       $(transport == Genie.WebChannels &&
@@ -236,8 +239,8 @@ function vue_integration(::Type{M};
     initStipple('#$vue_app_name');
     initWatchers();
 
-    Genie.WebChannels.subscriptionHandlers.push(function(event) {
-      app_ready();
+    $vue_app_name.WebChannel.subscriptionHandlers.push(function(event) {
+      app_$(vue_app_name)_ready();
     });
   }
   """

--- a/src/Layout.jl
+++ b/src/Layout.jl
@@ -41,18 +41,19 @@ julia> layout([
 "<link href=\"https://fonts.googleapis.com/css?family=Material+Icons\" rel=\"stylesheet\" /><link href=\"https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,400;0,700;0,900;1,400&display=swap\" rel=\"stylesheet\" /><link href=\"/css/stipple/stipplecore.css\" rel=\"stylesheet\" /><link href=\"/css/stipple/quasar.min.css\" rel=\"stylesheet\" /><span v-text='greeting'>Hello</span><script src=\"/js/channels.js?v=1.17.1\"></script><script src=\"/js/underscore-min.js\"></script><script src=\"/js/vue.global.prod.js\"></script><script src=\"/js/quasar.umd.prod.js\"></script>\n<script src=\"/js/apexcharts.min.js\"></script><script src=\"/js/vue-apexcharts.min.js\"></script><script src=\"/js/stipplecore.js\" defer></script><script src=\"/js/vue_filters.js\" defer></script>"
 ```
 """
-function layout(output::Union{S,Vector}, m::M;
+function layout(output::Union{S,Vector}, m::Union{M, Vector{M}};
                 partial::Bool = false, title::String = "", class::String = "", style::String = "", head_content::Union{AbstractString, Vector{<:AbstractString}} = "",
                 channel::String = Stipple.channel_js_name,
                 core_theme::Bool = true)::ParsedHTMLString where {M<:ReactiveModel, S<:AbstractString}
 
   isa(output, Vector) && (output = join(output, '\n'))
+  m isa Vector || (m = [m])
 
   content = [
     output
     theme(; core_theme)
-    Stipple.deps(m)
-  ]
+    Stipple.deps.(m)...
+  ] |> union
 
   partial && return content
 
@@ -84,17 +85,22 @@ julia> page(:elemid, [
 "<!DOCTYPE html>\n<html><head><title></title><meta name=\"viewport\" content=\"width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, minimal-ui\" /></head><body class style><link href=\"https://fonts.googleapis.com/css?family=Material+Icons\" rel=\"stylesheet\" /><link href=\"https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,400;0,700;0,900;1,400&display=swap\" rel=\"stylesheet\" /><link href=\"/css/stipple/stipplecore.css\" rel=\"stylesheet\" /><link href=\"/css/stipple/quasar.min.css\" rel=\"stylesheet\" /><div id=elemid><span v-text='greeting'>Hello</span></div><script src=\"/js/channels.js?v=1.17.1\"></script><script src=\"/js/underscore-min.js\"></script><script src=\"/js/vue.global.prod.js\"></script><script src=\"/js/quasar.umd.prod.js\"></script>\n<script src=\"/js/apexcharts.min.js\"></script><script src=\"/js/vue-apexcharts.min.js\"></script><script src=\"/js/stipplecore.js\" defer></script><script src=\"/js/vue_filters.js\" defer></script></body></html>"
 ```
 """
-function page(model::M, args...;
+function page(model::Union{M, Vector{M}}, args...;
               partial::Bool = false, title::String = "", class::String = "container", style::String = "",
               channel::String = Genie.config.webchannels_default_route, head_content::Union{AbstractString, Vector{<:AbstractString}} = "",
               prepend::Union{S,Vector} = "", append::Union{T,Vector} = [],
               core_theme::Bool = true,
               kwargs...)::ParsedHTMLString where {M<:Stipple.ReactiveModel, S<:AbstractString,T<:AbstractString}
-
+  model isa Vector || (model = [model])
+  uis = if !isempty(args)
+    args[1] isa Vector ? args[1] : [args[1]]
+  else
+    ""
+  end
   layout(
     [
       join(prepend)
-      Genie.Renderer.Html.div(id = vm(M), args...; class = class, kwargs...)
+      [Genie.Renderer.Html.div(id = vm(m), ui, args[2:end]...; class = class, kwargs...) for (m, ui) in zip(model, uis)]...
       join(append)
     ], model;
     partial = partial, title = title, style = style, head_content = head_content, channel = channel,

--- a/src/Layout.jl
+++ b/src/Layout.jl
@@ -98,14 +98,21 @@ function page(model::Union{M, Vector{M}}, args...;
   else
     ""
   end
+  counter = Dict{DataType, Int}()
+
+  function rootselector(m::M) where M <:ReactiveModel
+    AM = Stipple.get_abstract_type(M)
+    counter[AM] = get(counter, AM, -1) + 1
+    return (counter[AM] == 0) ? vm(m) : "$(vm(m))-$(counter[AM])"
+  end
+
   layout(
     [
       join(prepend)
-      pagetemplate([Genie.Renderer.Html.div(id = vm(m), ui, args[2:end]...; class = class, kwargs...) for (m, ui) in zip(model, uis)]...)
+      pagetemplate([Genie.Renderer.Html.div(id = rootselector(m), ui, args[2:end]...; class = class, kwargs...) for (m, ui) in zip(model, uis)]...)
       join(append)
     ], model;
-    partial = partial, title = title, style = style, head_content = head_content, channel = channel,
-    core_theme = core_theme)
+    partial, title, style, head_content, channel, core_theme)
 end
 
 const app = page

--- a/src/Layout.jl
+++ b/src/Layout.jl
@@ -102,8 +102,8 @@ function page(model::Union{M, Vector{M}}, args...;
 
   function rootselector(m::M) where M <:ReactiveModel
     AM = Stipple.get_abstract_type(M)
-    counter[AM] = get(counter, AM, -1) + 1
-    return (counter[AM] == 0) ? vm(m) : "$(vm(m))-$(counter[AM])"
+    counter[AM] = get(counter, AM, 0) + 1
+    return (counter[AM] == 1) ? vm(m) : "$(vm(m))-$(counter[AM])"
   end
 
   layout(

--- a/src/Layout.jl
+++ b/src/Layout.jl
@@ -17,6 +17,25 @@ const THEMES = Ref(Function[])
 const FLEXGRID_KWARGS = [:col, :xs, :sm, :md, :lg, :xl, :gutter, :xgutter, :ygutter]
 
 """
+    make_unique!(src::Vector, condition::Union{Nothing, Function} = nothing)
+
+Utility function for removing duplicates from a vector that fulfill a given condition.
+"""
+function make_unique!(src::Vector, condition::Union{Nothing, Function} = nothing)
+  seen = Int[]
+  dups = Int[]
+  for (i, name) in enumerate(src)
+      if name ∈ view(src, seen) && (condition === nothing || condition(name))
+          push!(dups, i)
+      else
+          push!(seen, i)
+      end
+  end
+
+  deleteat!(src, dups)
+end
+
+"""
     function layout(output::Union{String,Vector}; partial::Bool = false, title::String = "", class::String = "", style::String = "",
                       head_content::String = "", channel::String = Genie.config.webchannels_default_route) :: String
 
@@ -53,7 +72,9 @@ function layout(output::Union{S,Vector}, m::Union{M, Vector{M}};
     output
     theme(; core_theme)
     Stipple.deps.(m)...
-  ] |> union
+  ]
+
+  make_unique!(content, contains(r"src=|href="i))
 
   partial && return content
 

--- a/src/Layout.jl
+++ b/src/Layout.jl
@@ -86,6 +86,7 @@ julia> page(:elemid, [
 ```
 """
 function page(model::Union{M, Vector{M}}, args...;
+              pagetemplate = (x...) -> join([x...], '\n'),
               partial::Bool = false, title::String = "", class::String = "container", style::String = "",
               channel::String = Genie.config.webchannels_default_route, head_content::Union{AbstractString, Vector{<:AbstractString}} = "",
               prepend::Union{S,Vector} = "", append::Union{T,Vector} = [],
@@ -100,7 +101,7 @@ function page(model::Union{M, Vector{M}}, args...;
   layout(
     [
       join(prepend)
-      [Genie.Renderer.Html.div(id = vm(m), ui, args[2:end]...; class = class, kwargs...) for (m, ui) in zip(model, uis)]...
+      pagetemplate([Genie.Renderer.Html.div(id = vm(m), ui, args[2:end]...; class = class, kwargs...) for (m, ui) in zip(model, uis)]...)
       join(append)
     ], model;
     partial = partial, title = title, style = style, head_content = head_content, channel = channel,

--- a/src/Stipple.jl
+++ b/src/Stipple.jl
@@ -853,6 +853,12 @@ function channelscript(channel::String) :: String
   """])
 end
 
+function initscript(vue_app_name) :: String
+  Genie.Renderer.Html.script(["""
+  // script id: $(randstring(64))
+  document.addEventListener("DOMContentLoaded", () => window.create$vue_app_name() );
+  """])
+end
 
 """
     function deps(channel::String = Genie.config.webchannels_default_route)
@@ -863,6 +869,7 @@ function deps(m::M) :: Vector{String} where {M<:ReactiveModel}
   channel = getchannel(m)
   output = [
     channelscript(channel),
+    initscript(vm(m)),
     (is_channels_webtransport() ? Genie.Assets.channels_script_tag(channel) : Genie.Assets.webthreads_script_tag(channel)),
     Genie.Renderer.Html.script(src = Genie.Assets.asset_path(assets_config, :js, file="underscore-min")),
     Genie.Renderer.Html.script(src = Genie.Assets.asset_path(assets_config, :js, file=(Genie.Configuration.isprod() ? "vue.global.prod" : "vue.global"))),

--- a/src/Stipple.jl
+++ b/src/Stipple.jl
@@ -342,10 +342,10 @@ changed on the frontend, it is pushed over to the backend using `channel`, at a 
 function watch(vue_app_name::String, fieldname::Symbol, channel::String, debounce::Int, model::M; jsfunction::String = "")::String where {M<:ReactiveModel}
   js_channel = isempty(channel) ?
                 "window.Genie.Settings.webchannels_default_route" :
-                (channel == Stipple.channel_js_name ? Stipple.channel_js_name : "'$channel'")
+                "$vue_app_name.channel_"
 
   isempty(jsfunction) &&
-    (jsfunction = "Genie.WebChannels.sendMessageTo($js_channel, 'watchers', {'payload': {'field':'$fieldname', 'newval': newVal, 'oldval': oldVal, 'sesstoken': document.querySelector(\"meta[name='sesstoken']\")?.getAttribute('content')}});")
+    (jsfunction = "$vue_app_name.WebChannel.sendMessageTo($js_channel, 'watchers', {'payload': {'field':'$fieldname', 'newval': newVal, 'oldval': oldVal, 'sesstoken': document.querySelector(\"meta[name='sesstoken']\")?.getAttribute('content')}});")
 
   output = IOBuffer()
   if fieldname == :isready
@@ -847,7 +847,10 @@ end
 
 
 function channelscript(channel::String) :: String
-  Genie.Renderer.Html.script(["window.CHANNEL = '$(channel)';"])
+  Genie.Renderer.Html.script(["""
+  window.CHANNEL = '$(channel)';
+  if (window.Genie) Genie.init_webchannel('$(channel)');
+  """])
 end
 
 

--- a/src/Stipple.jl
+++ b/src/Stipple.jl
@@ -848,7 +848,7 @@ end
 # no longer needed, replaced by initscript
 function channelscript(channel::String) :: String
   Genie.Renderer.Html.script(["""
-  document.addEventListener('DOMContentLoaded', () => window.Genie.initWebChannel('$dchannel') );
+  document.addEventListener('DOMContentLoaded', () => window.Genie.initWebChannel('$channel') );
   """])
 end
 

--- a/src/Stipple.jl
+++ b/src/Stipple.jl
@@ -113,7 +113,7 @@ using .NamedTuples
 export JSONParser, JSONText, json, @json, jsfunction, @jsfunction_str
 
 const config = Genie.config
-const channel_js_name = "window.CHANNEL"
+const channel_js_name = "'not_assigned'"
 
 const OptDict = OrderedDict{Symbol, Any}
 opts(;kwargs...) = OptDict(kwargs...)
@@ -345,7 +345,7 @@ function watch(vue_app_name::String, fieldname::Symbol, channel::String, debounc
                 "$vue_app_name.channel_"
 
   isempty(jsfunction) &&
-    (jsfunction = "$vue_app_name.WebChannel.sendMessageTo($js_channel, 'watchers', {'payload': {'field':'$fieldname', 'newval': newVal, 'oldval': oldVal, 'sesstoken': document.querySelector(\"meta[name='sesstoken']\")?.getAttribute('content')}});")
+    (jsfunction = "$vue_app_name.push('$fieldname')")
 
   output = IOBuffer()
   if fieldname == :isready
@@ -848,8 +848,7 @@ end
 
 function channelscript(channel::String) :: String
   Genie.Renderer.Html.script(["""
-  window.CHANNEL = '$(channel)'; // probably no longer required, but in runtests still used
-  document.addEventListener("DOMContentLoaded", () => Genie.initWebChannel('$(channel)') );
+  document.addEventListener("DOMContentLoaded", () => window.Genie.initWebChannel('$(channel)') );
   """])
 end
 

--- a/src/Stipple.jl
+++ b/src/Stipple.jl
@@ -848,13 +848,13 @@ end
 
 function channelscript(channel::String) :: String
   Genie.Renderer.Html.script(["""
-  document.addEventListener("DOMContentLoaded", () => window.Genie.initWebChannel('$(channel)') );
+  document.addEventListener('DOMContentLoaded', () => window.Genie.initWebChannel('$dchannel') );
   """])
 end
 
-function initscript(vue_app_name) :: String
+function initscript(vue_app_name, channel) :: String
   Genie.Renderer.Html.script(["""
-  document.addEventListener("DOMContentLoaded", () => window.create$vue_app_name() );
+  document.addEventListener('DOMContentLoaded', () => window.create$vue_app_name('$channel') );
   """])
 end
 
@@ -866,8 +866,8 @@ Outputs the HTML code necessary for injecting the dependencies in the page (the 
 function deps(m::M) :: Vector{String} where {M<:ReactiveModel}
   channel = getchannel(m)
   output = [
-    channelscript(channel),
-    initscript(vm(m)),
+    # channelscript(channel),
+    initscript(vm(m), channel),
     (is_channels_webtransport() ? Genie.Assets.channels_script_tag(channel) : Genie.Assets.webthreads_script_tag(channel)),
     Genie.Renderer.Html.script(src = Genie.Assets.asset_path(assets_config, :js, file="underscore-min")),
     Genie.Renderer.Html.script(src = Genie.Assets.asset_path(assets_config, :js, file=(Genie.Configuration.isprod() ? "vue.global.prod" : "vue.global"))),

--- a/src/Stipple.jl
+++ b/src/Stipple.jl
@@ -849,7 +849,7 @@ end
 function channelscript(channel::String) :: String
   Genie.Renderer.Html.script(["""
   window.CHANNEL = '$(channel)';
-  if (window.Genie) Genie.init_webchannel('$(channel)');
+  if (window.Genie) Genie.initWebChannel('$(channel)');
   """])
 end
 

--- a/src/Stipple.jl
+++ b/src/Stipple.jl
@@ -854,7 +854,6 @@ end
 
 function initscript(vue_app_name) :: String
   Genie.Renderer.Html.script(["""
-  // script id: $(randstring(64))
   document.addEventListener("DOMContentLoaded", () => window.create$vue_app_name() );
   """])
 end

--- a/src/Stipple.jl
+++ b/src/Stipple.jl
@@ -848,8 +848,8 @@ end
 
 function channelscript(channel::String) :: String
   Genie.Renderer.Html.script(["""
-  window.CHANNEL = '$(channel)';
-  if (window.Genie) Genie.initWebChannel('$(channel)');
+  window.CHANNEL = '$(channel)'; // probably no longer required, but in runtests still used
+  document.addEventListener("DOMContentLoaded", () => Genie.initWebChannel('$(channel)') );
   """])
 end
 

--- a/src/Stipple.jl
+++ b/src/Stipple.jl
@@ -845,7 +845,7 @@ function injectdeps(output::Vector{AbstractString}, M::Type{<:ReactiveModel}) ::
   output
 end
 
-
+# no longer needed, replaced by initscript
 function channelscript(channel::String) :: String
   Genie.Renderer.Html.script(["""
   document.addEventListener('DOMContentLoaded', () => window.Genie.initWebChannel('$dchannel') );
@@ -866,7 +866,6 @@ Outputs the HTML code necessary for injecting the dependencies in the page (the 
 function deps(m::M) :: Vector{String} where {M<:ReactiveModel}
   channel = getchannel(m)
   output = [
-    # channelscript(channel),
     initscript(vm(m), channel),
     (is_channels_webtransport() ? Genie.Assets.channels_script_tag(channel) : Genie.Assets.webthreads_script_tag(channel)),
     Genie.Renderer.Html.script(src = Genie.Assets.asset_path(assets_config, :js, file="underscore-min")),

--- a/src/stipple/jsmethods.jl
+++ b/src/stipple/jsmethods.jl
@@ -204,7 +204,7 @@ myreviver: function(key, value) { return (key.endsWith('_onebased') ? value - 1 
 """  
 function js_add_reviver(revivername::String)
   """
-  document.addEventListener("DOMContentLoaded", () => Genie.WebChannels.subscriptionHandlers.push(function(event) {
+  document.addEventListener('DOMContentLoaded', () => Genie.WebChannels.subscriptionHandlers.push(function(event) {
       Genie.Revivers.addReviver($revivername);
   }));
   """
@@ -222,7 +222,7 @@ It needs to be added to the dependencies of an app in order to be executed, e.g.
 """
 function js_initscript(initscript::String)
   """
-  document.addEventListener("DOMContentLoaded", () => Genie.WebChannels.subscriptionHandlers.push(function(event) {
+  document.addEventListener('DOMContentLoaded', () => Genie.WebChannels.subscriptionHandlers.push(function(event) {
       $(initscript)
   }));
   """

--- a/src/stipple/jsmethods.jl
+++ b/src/stipple/jsmethods.jl
@@ -36,10 +36,11 @@ function js_methods(app::T)::String where {T<:ReactiveModel}
   ""
 end
 
+# deprecated, now part of the model
 function js_methods_events()::String
 """
   handle_event: function (event, handler) {
-    Genie.WebChannels.sendMessageTo(window.CHANNEL, 'events', {
+    Genie.WebChannels.sendMessageTo(GENIEMODEL.channel_, 'events', {
         'event': {
             'name': handler,
             'event': event

--- a/src/stipple/jsmethods.jl
+++ b/src/stipple/jsmethods.jl
@@ -204,9 +204,9 @@ myreviver: function(key, value) { return (key.endsWith('_onebased') ? value - 1 
 """  
 function js_add_reviver(revivername::String)
   """
-  Genie.WebChannels.subscriptionHandlers.push(function(event) {
+  document.addEventListener("DOMContentLoaded", () => Genie.WebChannels.subscriptionHandlers.push(function(event) {
       Genie.Revivers.addReviver($revivername);
-  });
+  }));
   """
 end
 
@@ -222,9 +222,9 @@ It needs to be added to the dependencies of an app in order to be executed, e.g.
 """
 function js_initscript(initscript::String)
   """
-  Genie.WebChannels.subscriptionHandlers.push(function(event) {
+  document.addEventListener("DOMContentLoaded", () => Genie.WebChannels.subscriptionHandlers.push(function(event) {
       $(initscript)
-  });
+  }));
   """
 end
 

--- a/src/stipple/rendering.jl
+++ b/src/stipple/rendering.jl
@@ -135,7 +135,7 @@ function Stipple.render(app::M)::Dict{Symbol,Any} where {M<:ReactiveModel}
   for field in fieldnames(typeof(app))
     f = getfield(app, field)
 
-    occursin(SETTINGS.private_pattern, String(field)) && continue
+    field != CHANNELFIELDNAME && occursin(SETTINGS.private_pattern, String(field)) && continue
     f isa Reactive && f.r_mode == PRIVATE && continue
 
     result[field] = Stipple.jsrender(f, field)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,7 +10,7 @@ function string_get(x; kwargs...)
 end
 
 function get_channel(s::String)
-    match(r"window.CHANNEL = '([^']+)'", s).captures[1]
+    match(r"initWebChannel\('([^']+)'", s).captures[1]
 end
 
 function get_debounce(port, modelname)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,7 +10,7 @@ function string_get(x; kwargs...)
 end
 
 function get_channel(s::String)
-    match(r"initWebChannel\('([^']+)'", s).captures[1]
+    match(r"\(\) => window.create[^']+'([^']+)'", s).captures[1]
 end
 
 function get_debounce(port, modelname)


### PR DESCRIPTION
This PR fixes at least part of what was requested in https://github.com/GenieFramework/Stipple.jl/issues/171.
It goes together with a respective PR in Genie.

We now support multiple models on a single page, even models of the same type.
Each model has its own websocket connection, with its own keepalive timer and ws_disonnected field.
The reconnection loop issue has also been fixed.

MWE:
```jullia
using Stipple, Stipple.ReactiveTools
using StippleUI

@app MyApp1 begin
    @in i = 0
    
    @onchange i begin
        @notify("i has changed $i")
    end
end handlers1

@app MyApp2 begin
    @in j = 0

    @onchange j begin
        @notify("j has changed $j")
    end
end handlers2

@app MyApp3 begin
    @in k = 0

    @onchange k begin
        @notify("k has changed $k")
    end
end handlers3

ui(field = :i) = () -> row(card([
    cardsection(h6("Websocket disconnected"), @if(:ws_disconnected))
    cardsection(numberfield(String(field), field))
    cardsection(textfield("$field text", field))
]))

route("/") do
    global model1 = init(MyApp1, channel = Stipple.channelfactory()) |> handlers1
    global model2 = init(MyApp2, channel = Stipple.channelfactory()) |> handlers2
    global model3 = init(MyApp3, channel = Stipple.channelfactory()) |> handlers3
    page([model1, model2, model3], [ui(:i), ui(:j), ui(:k)], pagetemplate = (x...) -> row([x...]), "v-cloak") |> html
end

route("/multi") do
    global models = [init(MyApp1, channel = Stipple.channelfactory()) |> handlers1 for _ in 1:5]    
    page(models, fill(ui(), length(models)), pagetemplate = (x...) -> row([x...]), "v-cloak") |> html
end

up(open_browser = true)
```
<img width="415" alt="image" src="https://github.com/user-attachments/assets/28890a69-1313-449e-83fd-405eb521b1bd">
<img width="550" alt="image" src="https://github.com/user-attachments/assets/826f147a-8ec4-4aec-9e8a-e45fa626d314">
