### PR TITLE
add Pages.routehandler

### DIFF
--- a/src/Pages.jl
+++ b/src/Pages.jl
@@ -12,7 +12,6 @@ using Stipple
 
 export Page
 export pages
-export routehandler
 
 @vars EmptyModel begin
 end
@@ -28,9 +27,6 @@ end
 const _pages = Page[]
 pages() = _pages
 
-routehandler(model::ReactiveModel, ::Any) = routehandler(model)
-routehandler(::ReactiveModel) = nothing
-
 function Page(  route::Union{Route,String};
                 view::Union{Genie.Renderers.FilePath,<:AbstractString,ParsedHTMLString,Vector{<:AbstractString},Function},
                 model::Union{M,Function,Nothing,Expr,Module,Type{M}} = Stipple.init(EmptyModel),
@@ -40,48 +36,57 @@ function Page(  route::Union{Route,String};
                 throttle::Int = Stipple.JS_THROTTLE_TIME,
                 transport::Module = Stipple.WEB_TRANSPORT[],
                 core_theme::Bool = true,
+                pre::Union{Function, Vector{<:Function}} = Function[],
+                post::Union{Function, Vector{<:Function}} = Function[],
                 kwargs...
               ) where {M<:ReactiveModel}
 
-  routepath = Symbol(route isa Route ? route.path : route)
-  model = if isa(model, Expr)
-            Core.eval(context, model)
-          elseif isa(model, Module)
-            context = model
-            () -> Stipple.ReactiveTools.init_model(context; debounce, throttle, transport, core_theme)
-          elseif model isa DataType
-            # as model is being redefined, we need to create a copy
-            mymodel = model
-            () -> Stipple.ReactiveTools.init_model(mymodel; debounce, throttle, transport, core_theme)
-          else
-            model
-          end
-  view =  if isa(view, Function) || isa(view, ParsedHTMLString)
-            view
-          elseif isa(view, Vector{ParsedHTMLString})
-            ParsedHTMLString(view)
-          elseif isa(view, Vector{<:AbstractString})
-            join(view)
-          elseif isa(view, AbstractString)
-            isfile(view) ? filepath(view) : view
-          else
-            view
-          end
+  model isa Expr && (model = @eval context model)
+  view = if isa(view, Function) || isa(view, ParsedHTMLString)
+    view
+  elseif isa(view, Vector{ParsedHTMLString})
+    ParsedHTMLString(view)
+  elseif isa(view, Vector{<:AbstractString})
+    join(view)
+  elseif isa(view, AbstractString)
+    isfile(view) ? filepath(view) : view
+  else
+    view
+  end
 
   route = isa(route, String) ? Route(; method = GET, path = route) : route
-  layout = isa(layout, String) && length(layout) < Stipple.IF_ITS_THAT_LONG_IT_CANT_BE_A_FILENAME && isfile(layout) ? filepath(layout) :
-            isa(layout, ParsedHTMLString) || isa(layout, String) ? string(layout) :
-              layout
 
-  route.action = function ()
-    model = model isa Function ? Base.invokelatest(model) : model
-    page = view isa Function ? html! : html
-    result = routehandler(model, Val(routepath))
-    result !== nothing && return result
-    page(view; layout, context, model, kwargs...)
+  layout = if isa(layout, String) && length(layout) < Stipple.IF_ITS_THAT_LONG_IT_CANT_BE_A_FILENAME && isfile(layout)
+    filepath(layout)
+  elseif isa(layout, ParsedHTMLString) || isa(layout, String)
+    string(layout)
+  else
+    layout
   end
 
   page = Page(route, view, model, layout, context)
+
+  pre isa Function && (pre = [pre])
+  post isa Function && (post = [post])
+  
+  route.action = function ()
+    for f in pre
+      result = f()
+      result !== nothing && return result
+    end
+    model = if page.model isa DataType && page.model <: ReactiveModel || page.model isa Module
+      Stipple.ReactiveTools.init_model(page.model; debounce, throttle, transport, core_theme)
+    else
+      page.model
+    end
+    for f in post
+      result = f(model)
+      result !== nothing && return result
+    end
+
+    page_fn = view isa Function ? html! : html
+    page_fn(view; layout, context, model = model, kwargs...)
+  end
 
   if isempty(_pages)
     push!(_pages, page)

--- a/src/Pages.jl
+++ b/src/Pages.jl
@@ -28,8 +28,8 @@ end
 const _pages = Page[]
 pages() = _pages
 
-routehandler(model::ReactiveModel, routepath) = routehandler(model)
-routehandler(model::ReactiveModel) = nothing
+routehandler(model::ReactiveModel, ::Any) = routehandler(model)
+routehandler(::ReactiveModel) = nothing
 
 function Page(  route::Union{Route,String};
                 view::Union{Genie.Renderers.FilePath,<:AbstractString,ParsedHTMLString,Vector{<:AbstractString},Function},
@@ -76,7 +76,7 @@ function Page(  route::Union{Route,String};
   route.action = function ()
     model = model isa Function ? Base.invokelatest(model) : model
     page = view isa Function ? html! : html
-    result = routehandler(model, routepath)
+    result = routehandler(model, Val(routepath))
     result !== nothing && return result
     page(view; layout, context, model, kwargs...)
   end

--- a/src/ReactiveTools.jl
+++ b/src/ReactiveTools.jl
@@ -1304,13 +1304,12 @@ end
 macro event(M, eventname, expr)
   known_reactive_vars, known_non_reactive_vars = get_known_vars(@eval(__module__, $M))
   known_vars = vcat(known_reactive_vars, known_non_reactive_vars)
-  expr, used_vars = mask(expr, known_vars)
-
+  
+  expr, _ = mask(expr, known_vars)
   expr = fieldnames_to_fields(expr, known_non_reactive_vars)
   expr = fieldnames_to_fieldcontent(expr, known_reactive_vars)
   expr = unmask(expr, known_vars)
 
-  expr = unmask(fieldnames_to_fieldcontent(expr, known_vars), known_vars)
   T = eventname isa QuoteNode ? eventname : QuoteNode(eventname)
 
   quote

--- a/src/ReactiveTools.jl
+++ b/src/ReactiveTools.jl
@@ -1114,7 +1114,13 @@ end
 
 """
 ```julia
-@page(url, view)
+@page(url, view; model::Union{Module, Type{<:ReactiveModel}, ReactiveModel},
+                layout::Union{Genie.Renderers.FilePath,<:AbstractString,ParsedHTMLString,Nothing,Function} = nothing
+                debounce::Int = Stipple.JS_DEBOUNCE_TIME,
+                throttle::Int = Stipple.JS_THROTTLE_TIME,
+                core_theme::Bool = true,
+                pre::Union{Function, Vector{<:Function}} = Function[],
+                post::Union{Function, Vector{<:Function}} = Function[])
 ```
 Registers a new page with source in `view` to be rendered at the route `url`.
 
@@ -1125,6 +1131,30 @@ Registers a new page with source in `view` to be rendered at the route `url`.
 
 @page("/", ui; model = MyApp) # for specifying an explicit app
 ```
+### Other Parameters
+- `debounce`: debounce time in ms
+- `throttle`: throttle time in ms
+- `core_theme`: whether to use the core theme
+- `pre`: pre-rendering functions, e.g. for authentication
+
+   Function definition: `pre1() = println("pre1").
+
+   Call: `@page("/", ui, pre = pre1)` or `@page("/", ui, pre = [pre1, pre2, ...])`
+   
+   If the result of the function is not `nothing`, the rendering will be stopped and the result will be returned.
+- `post`: post-rendering functions, e.g. for modification of initial values of the model
+
+   Function definition:
+
+   ```
+   @handler function post1();
+       println("post1");
+       x = new_x;
+       println("changed initial value of :x to new_x");
+   end
+    ```
+    Model variables are accessible and can be modified in the post-rendering functions. For more details see [`@handler`](@ref).
+    Note that you need a model handler `@onchange isready @push` or `@onchange isready @push x` to update the variables after the model is ready.
 """
 macro page(expressions...)
     # for macros to support semicolon parameter syntax it's required to have no positional arguments in the definition

--- a/src/Stipple.jl
+++ b/src/Stipple.jl
@@ -521,7 +521,7 @@ end
 function Base.notify(model::ReactiveModel, event)
   T = typeof(event)
   event_name = T.name == Base.typename(Val) ? ":$(T.parameters[1])" : event
-  println("No event '$event_name' defined")
+  @info("Warning: No event '$event_name' defined")
 end
 
 """

--- a/src/Stipple.jl
+++ b/src/Stipple.jl
@@ -1147,8 +1147,6 @@ end
 #===#
 
 include("Pages.jl")
-import .Pages.routehandler
-export routehandler
 
 #===#
 

--- a/src/Stipple.jl
+++ b/src/Stipple.jl
@@ -1147,6 +1147,8 @@ end
 #===#
 
 include("Pages.jl")
+import .Pages.routehandler
+export routehandler
 
 #===#
 


### PR DESCRIPTION
Currently there is no way of authentication implemented in the ReactiveTools API, nor a way of manipulating models directly after instantiation.
This PR impplements a routehandler that can be the base of both. It is defined to be `nothing` per default.
```julia
routehandler(model::ReactiveModel, ::Any) = routehandler(model)
routehandler(::ReactiveModel) = nothing
```
It is called by the Page action directly after model initialisation.
If the result is not `nothing` the return value of the routehandler is returned, otherwise the standard page is delivered.

### MWE
```julia
@app MyApp begin
    @in dt = 1
end

@page("/", "Hello world", model = MyApp)
@page("/test", "Hello test", model = MyApp)

# define a general routehandler
Stipple.routehandler(::MyApp) = println("route: ", params(:ROUTE).path, "\nsession: ", GenieSession.session().id)

# define a route-specific routehandler
function Stipple.routehandler(model::MyApp, ::Val{Symbol("/test"})
    result = routehandler(model)
    result === nothing || return result
    println("Extra handling of route '/test'")
end
```
you get
```julia-repl
julia> HTTP.get("http://localhost:8000");
route: /
session: 0b45b76297b44fb0214f4f947ef09658204c665bf339cfbe9b03ea9f268b2b6a
[ Info: GET / 200

julia> HTTP.get("http://localhost:8000/test");
route: /test
session: 0b45b76297b44fb0214f4f947ef09658204c665bf339cfbe9b03ea9f268b2b6a
Extra handling of route '/test'
[ Info: GET /test 200
```
In real life one could implement authentication/redirection for all pages of a model at once and define specific conditions for pages like admin pages.
@essenciary would be happy to know what you think.