### PR TITLE
Generate Vue components from apps

### DIFF
--- a/src/Stipple.jl
+++ b/src/Stipple.jl
@@ -94,7 +94,8 @@ using Logging, Mixers, Random, Reexport, Dates, Tables
 @reexport @using_except Genie: download
 import Genie.Router.download
 @reexport @using_except Genie.Renderers.Html: mark, div, time, view, render, Headers, menu
-export render, htmldiv, js_attr
+export render, htmldiv, js_attr, render_component
+
 @reexport using JSON3
 @reexport using StructTypes
 @reexport using Parameters

--- a/src/stipple/components.jl
+++ b/src/stipple/components.jl
@@ -15,7 +15,13 @@ Stipple.register_components(HelloPie, StippleCharts.COMPONENTS)
 function register_components(model::Type{M}, keysvals::Union{AbstractVector, AbstractDict}; legacy::Bool = false) where {M<:ReactiveModel}
   haskey(COMPONENTS, model) || (COMPONENTS[model] = LittleDict())
   for kv in keysvals
-    (k, v) = kv isa Pair ? kv : (kv, kv)
+    (k, v) = if kv isa Pair
+      kv
+    elseif kv isa DataType && kv <: ReactiveModel
+      js_name(kv), render_component(kv)
+    else
+      kv, kv
+    end
     legacy && (v = "window.vueLegacy.components['$v']")
     delete!(COMPONENTS[model], k)
     push!(COMPONENTS[model], k => v)

--- a/src/stipple/jsmethods.jl
+++ b/src/stipple/jsmethods.jl
@@ -111,6 +111,19 @@ end
 
 const jswatch = js_watch
 
+function js_props(m::T)::String where {T<:ReactiveModel}
+  ""
+end
+
+const jsprops = js_props
+
+function js_template(m::T)::String where {T<:ReactiveModel}
+  ""
+end
+
+const jstemplate = js_template
+
+
 """
     function client_data(app::T)::String where {T<:ReactiveModel}
 


### PR DESCRIPTION
Writing and registering Vue components has been a bit tedious in the past.

With this - rather small - PR we can use normal app syntax to write and register Vue components:

# Demo of a Copy Button
```julia
using Stipple, Stipple.ReactiveTools
using StippleUI
import Stipple.opts

# defining a simple copy button component
@app VueCopyButton begin
    @out copied = false
end

@methods VueCopyButton [
    :handleCopy => js"""function () {
        const text = typeof this.text === 'function' ? this.text() : this.text;
        Quasar.copyToClipboard(text).then(() => {
          this.copied = true;
          setTimeout(() => {
            this.copied = false;
          }, 700);
        });
      }
    """
]

@props VueCopyButton opts(
    text = opts(
        type = [js"String", js"Function"],
        required = true
    )
)

@template VueCopyButton btn(
    icon = R"this.copied ? 'check' : 'content_copy'",
    aria__label = R"this.copied ? 'Copied!' : 'Copy to clipboard'",
    flat = true, size = "sm",
    @click("this.handleCopy")
)

copybutton(text, args...; kwargs...) = vue(:copy__button, args...; text, kwargs...)

# defining a simple app with a copy button
@app MyApp begin
    @in text = "Copy this text"
end

# registering the component in the app
@components MyApp VueCopyButton

ui() = row([
    textfield("Text to be copied", :text, style = "max-width: 200px;"),
    copybutton(:text, class = "q-mt-md")
])

@page("/", ui, model = MyApp)
up(open_browser = true)
```
<img width="332" height="183" alt="image" src="https://github.com/user-attachments/assets/cc42a1c0-d4db-4d10-9d54-908f572e51fa" />
