### PR TITLE
Add authorization tools

### DIFF
--- a/src/Authorisation.jl
+++ b/src/Authorisation.jl
@@ -1,15 +1,15 @@
 """
-module Authorization
+module Authorisation
 
-Provides a collection of functions to handle user authorization:
-- `get_roles()`, `get_user()`, `is_authorized()`, `default_user()`, `default_role()`
+Provides a collection of functions to handle user authorisation:
+- `get_roles()`, `get_user()`, `is_authorised()`, `default_user()`, `default_role()`
 
-They are predefined such that get_user(App) returns the default user, who has the role default_role(App) and is authorized.
-In order to customize authorization get_user(App) and get_roles(App) or is_authorized(App) need to be overwritten.
+They are predefined such that get_user(App) returns the default user, who has the role default_role(App) and is authorised.
+In order to customize authorisation get_user(App) and get_roles(App) or is_authorised(App) need to be overwritten.
 
 ### Example 1 - Numbered Users and Admins for a all Apps
 ```julia
-using Stipple, Stipple.ReactiveTools, Stipple.Authorization
+using Stipple, Stipple.ReactiveTools, Stipple.Authorisation
 
 @app MyApp begin
     @in x = 1
@@ -24,10 +24,10 @@ Stipple.get_user(::Type{<:ReactiveModel}) = "user_1"
 get_roles(MyApp)
 # ["user"]
 
-is_authorized(MyApp)
+is_authorised(MyApp)
 # true
 
-is_authorized(MyApp, role = "admin")
+is_authorised(MyApp, role = "admin")
 # false
 
 # case 2: Admin
@@ -36,16 +36,16 @@ Stipple.get_user(::Type{MyApp}) = "admin_1"
 get_roles(MyApp)
 # ["admin"]
 
-is_authorized(MyApp)
+is_authorised(MyApp)
 # false
 
-is_authorized(MyApp, role = "admin")
+is_authorised(MyApp, role = "admin")
 # true
 ```
 
 ### Example 2 - User List via Roles for a single App
 ```julia
-using Stipple, Stipple.ReactiveTools, Stipple.Authorization
+using Stipple, Stipple.ReactiveTools, Stipple.Authorisation
 
 @app MyApp begin
     @in x = 1
@@ -60,11 +60,11 @@ Stipple.get_user(::Type{MyApp}) = "user_1"
 get_roles(MyApp)
 # ["user_1"]
 
-is_authorized(MyApp)
+is_authorised(MyApp)
 # false
 
 userlist() = ["user_1", "admin_1"]
-is_authorized(MyApp, role = userlist())
+is_authorised(MyApp, role = userlist())
 # true
 
 # case 2: Admin
@@ -73,13 +73,13 @@ Stipple.get_user(::Type{MyApp}) = "admin_1"
 get_roles(MyApp)
 # ["admin_1"]
 
-is_authorized(MyApp, role = userlist())
+is_authorised(MyApp, role = userlist())
 # true
 ```
 
-### Example 3 - Overwriting `is_authorized()` for a specific implicit model
+### Example 3 - Overwriting `is_authorised()` for a specific implicit model
 ```julia
-using Stipple, Stipple.ReactiveTools, Stipple.Authorization
+using Stipple, Stipple.ReactiveTools, Stipple.Authorisation
 
 # define an implicit model
 @app begin
@@ -91,34 +91,34 @@ userlist() = ["user_1", "admin_1"]
 # define `App` as the module's implicit model
 App = Stipple.@type
 
-# define `is_authorized()` for the implicit App
-# Note that it is important to allow for kwargs, because internal handling will call `is_authorized()` with the `role` kwarg.
-Stipple.is_authorized(::Type{App}, user::String; kwargs...) = user ∈ userlist()
+# define `is_authorised()` for the implicit App
+# Note that it is important to allow for kwargs, because internal handling will call `is_authorised()` with the `role` kwarg.
+Stipple.is_authorised(::Type{App}, user::String; kwargs...) = user ∈ userlist()
 
 Stipple.get_user(::Type{App}) = "user_1"
-is_authorized(App)
+is_authorised(App)
 # true
 
 Stipple.get_user(::Type{App}) = "user_2"
-is_authorized(App)
+is_authorised(App)
 # false
 
 Stipple.get_user(::Type{App}) = "admin_1"
-is_authorized(App)
+is_authorised(App)
 # true
 ```
 
-### Example 4 - applying authorization to a Genie web application
+### Example 4 - applying authorisation to a Genie web application
 
 ```julia
-using Stipple, Stipple.ReactiveTools, Stipple.Authorization
+using Stipple, Stipple.ReactiveTools, Stipple.Authorisation
 
 @app MyApp begin
     @in x = 1
 end
 
 # define a admin check which returns nothing in case of success and a not-found-page in case of failure
-admin_check() = is_authorized(MyApp, role = "admin") ? nothing : not_found()
+admin_check() = is_authorised(MyApp, role = "admin") ? nothing : not_found()
 
 ui() = "Hello Admin!"
 @page("/", ui, model = MyApp, pre = admin_check)
@@ -137,11 +137,11 @@ Genie.Server.openbrowser("http://localhost:8000")
 # Hello Admin!
 ```
 """
-module Authorization
+module Authorisation
 
 using Stipple
 
-export default_user, default_role, get_user, get_roles, is_authorized, not_found
+export default_user, default_role, get_user, get_roles, is_authorised, not_found
 
 not_found() = throw(Genie.Exceptions.NotFoundException(Genie.Requests.matchedroute().path))
 
@@ -161,7 +161,7 @@ end
 get_roles(::Type{App}) where App <: ReactiveModel = get_roles(App, get_user(App))
 get_roles(user::String = get_user(ReactiveModel)) = get_roles(ReactiveModel, user)
 
-function is_authorized(::Type{App}, user::String; role::Union{String, Vector{String}} = "user") where App
+function is_authorised(::Type{App}, user::String; role::Union{String, Vector{String}} = "user") where App
     roles = get_roles(App, user)
     if role isa String
         role ∈ roles
@@ -170,10 +170,10 @@ function is_authorized(::Type{App}, user::String; role::Union{String, Vector{Str
     end
 end
 
-function is_authorized(::Type{App}; role::Union{String, Vector{String}} = "user") where App <: ReactiveModel
-    is_authorized(App, get_user(App); role)
+function is_authorised(::Type{App}; role::Union{String, Vector{String}} = "user") where App <: ReactiveModel
+    is_authorised(App, get_user(App); role)
 end
 
-is_authorized(; role::Union{String, Vector{String}} = "user") = is_authorized(ReactiveModel; role)
+is_authorised(; role::Union{String, Vector{String}} = "user") = is_authorised(ReactiveModel; role)
 
-end # module Authorization
+end # module Authorisation

--- a/src/Authorization.jl
+++ b/src/Authorization.jl
@@ -1,0 +1,174 @@
+"""
+module Authorization
+
+Provides a collection of functions to handle user authorization:
+- `get_roles()`, `get_user()`, `is_authorized()`, `default_user()`, `default_role()`
+
+They are predefined such that get_user(App) returns the default user, who has the role default_role(App) and is authorized.
+In order to customize authorization get_user(App) and get_roles(App) or is_authorized(App) need to be overwritten.
+
+### Example 1 - numbered users and admins
+```julia
+using Stipple, Stipple.ReactiveTools, Stipple.Authorization
+
+@app MyApp begin
+    @in x = 1
+end
+
+# define roles as the first part of the string
+Stipple.get_roles(::Type{MyApp}, user::String) = String[split(user, '_')[1]]
+
+# case 1: normal user
+get_user(::Type{MyApp}) = "user_1"
+
+get_roles(MyApp)
+# ["user"]
+
+is_authorized(MyApp)
+# true
+
+is_authorized(MyApp, role = "admin")
+# false
+
+# case 2: Admin
+get_user(::Type{MyApp}) = "admin_1"
+
+get_roles(MyApp)
+# ["admin"]
+
+is_authorized(MyApp)
+# false
+
+is_authorized(MyApp, role = "admin")
+# true
+```
+
+### Example 2 - user list via roles
+```julia
+using Stipple, Stipple.ReactiveTools, Stipple.Authorization
+
+@app MyApp begin
+    @in x = 1
+end
+
+# make roles identical to user
+Stipple.get_roles(::Type{MyApp}, user::String) = [user]
+
+# case 1: normal user
+Stipple.get_user(::Type{MyApp}) = "user_1"
+
+get_roles(MyApp)
+# ["user_1"]
+
+is_authorized(MyApp)
+# false
+
+userlist() = ["user_1", "admin_1"]
+is_authorized(MyApp, role = userlist())
+# true
+
+# case 2: Admin
+Stipple.get_user(::Type{MyApp}) = "admin_1"
+
+get_roles(MyApp)
+# ["admin_1"]
+
+is_authorized(MyApp, role = userlist())
+# true
+```
+
+### Example 3 - using an implicit model and overwriting `is_authorized`
+```julia
+using Stipple, Stipple.ReactiveTools, Stipple.Authorization
+
+# define an implicit model
+@app begin
+    @in x = 1
+end
+
+userlist() = ["user_1", "admin_1"]
+
+# define `App` as the module's implicit model
+App = Stipple.@type
+
+# define `is_authorized()` for the implicit App
+# Note that it is important to allow for kwargs, because internal handling will call `is_authorized()` with the `role` kwarg.
+function is_authorized(::Type{App}, user::String; kwargs...) where App <: ReactiveModel
+    user ∈ userlist()
+end
+
+Stipple.get_user(::Type{App}) = "user_1"
+is_authorized(App)
+# true
+
+Stipple.get_user(::Type{App}) = "user_2"
+is_authorized(App)
+# false
+
+Stipple.get_user(::Type{App}) = "admin_1"
+is_authorized(App)
+# true
+```
+
+### Example 4 - applying authorization to a Genie web application
+
+```julia
+using Stipple, Stipple.Authorization
+
+@app MyApp begin
+    @in x = 1
+end
+
+# define a admin check which returns nothing in case of success and a not-found-page in case of failure
+admin_check() = is_authorized(MyApp, role = "admin") ? nothing : not_found()
+
+ui() = "Hello Admin!"
+@page("/", ui, model = MyApp, pre = admin_check)
+up()
+
+# define the role as first part of the string
+Stipple.get_roles(::Type{MyApp}, user::String) = String[split(user, '_')[1]]
+
+# case 1: normal user
+Stipple.get_user(::Type{MyApp}) = "user_1"
+Genie.Server.openbrowser("http://localhost:8000")
+# not-found-page
+
+Stipple.get_user(::Type{MyApp}) = "admin_1"
+Genie.Server.openbrowser("http://localhost:8000")
+# Hello Admin!
+```
+"""
+module Authorization
+
+using Stipple
+
+export default_user, default_role, get_user, get_roles, is_authorized, not_found
+
+not_found() = throw(Genie.Exceptions.NotFoundException(Genie.Requests.matchedroute().path))
+
+default_user(::Type{<:ReactiveModel})::String = "default"
+default_role(::Type{<:ReactiveModel})::String = "user"
+
+get_user(::Type{App}) where App <: ReactiveModel = default_user(App)
+
+function get_roles(::Type{App}, user::String) where App <: ReactiveModel
+    user == default_user(App) ? [default_role(App)] : String[]
+end
+
+get_roles(::Type{App}) where App <: ReactiveModel = get_roles(App, get_user(App))
+
+function is_authorized(::Type{App}, user::String; role::Union{String, Vector{String}} = "user") where App <: ReactiveModel
+    roles = get_roles(App, user)
+    if role isa String
+        role ∈ roles
+    else
+        !isempty(intersect(role, roles))
+    end
+end
+
+function is_authorized(::Type{App}; role::Union{String, Vector{String}} = "user") where App <: ReactiveModel
+    is_authorized(App, get_user(App); role)
+end
+
+end # module Authorization

--- a/src/Stipple.jl
+++ b/src/Stipple.jl
@@ -292,6 +292,7 @@ function init_storage end
 
 include("Tools.jl")
 include("Authorization.jl")
+using .Authorization
 include("ReactiveTools.jl")
 export @stipple_precompile
 

--- a/src/Stipple.jl
+++ b/src/Stipple.jl
@@ -291,6 +291,7 @@ function deletemode! end
 function init_storage end
 
 include("Tools.jl")
+include("Authorization.jl")
 include("ReactiveTools.jl")
 export @stipple_precompile
 

--- a/src/Stipple.jl
+++ b/src/Stipple.jl
@@ -291,8 +291,8 @@ function deletemode! end
 function init_storage end
 
 include("Tools.jl")
-include("Authorization.jl")
-using .Authorization
+include("Authorisation.jl")
+using .Authorisation
 include("ReactiveTools.jl")
 export @stipple_precompile
 


### PR DESCRIPTION
Currently user management is not part of Stipple. There is GenieAuthentication and GenieAuthorization, but both require GeniePlugins and SearchLight, and they involve the setup of a database, which makes things a bit heavy.
Moreover, even with these tools, it is not straight forward to integrate authorization into a web application.

This PR introduces a middle layer `Stipple.Authorization` that provides a collection of functions to handle user authorization:
- `get_roles()`
- `get_user()`
- `is_authorized()`
- `default_user()`
- `default_role()`
- `not_found()`

They are predefined such that `get_user(App)` returns the default user, who has the role `default_role(App)` and is authorized.
In order to customize authorization `get_user(App)` and `get_roles(App)` or `is_authorized(App)` need to be overwritten.

### Example - Numbered Users and Admins
```julia
using Stipple, Stipple.ReactiveTools, Stipple.Authorization

@app MyApp begin
    @in x = 1
end

# define a admin check which returns nothing in case of success and a not-found-page in case of failure
admin_check() = is_authorized(MyApp, role = "admin") ? nothing : not_found()

ui() = "Hello Admin!"
@page("/", ui, model = MyApp, pre = admin_check)
up()

# define the role as first part of the user string
Stipple.get_roles(::Type{MyApp}, user::String) = String[split(user, '_')[1]]

# case 1: normal user
Stipple.get_user(::Type{MyApp}) = "user_1"
Genie.Server.openbrowser("http://localhost:8000")
# not-found-page

# case 2: admin
Stipple.get_user(::Type{MyApp}) = "admin_1"
Genie.Server.openbrowser("http://localhost:8000")
# Hello Admin!