### PR TITLE
allow for precompilation of js assets by supplying the app's context to `Js.js()`

### DIFF
--- a/src/Stipple.jl
+++ b/src/Stipple.jl
@@ -752,17 +752,18 @@ function gb_compat_deps(::Type{M}) where M <: ReactiveModel
   Genie.Assets.add_fileroute(remote_assets_config, "vue.js"; basedir)
   Genie.Assets.add_fileroute(remote_assets_config, "vue_filters.js"; basedir)
   Genie.Router.route(Genie.Assets.asset_route(remote_assets_config, :js, file = vm(M))) do
-    Stipple.Elements.vue2_integration(M) |> Genie.Renderer.Js.js
+    Genie.Renderer.Js.js(Stipple.Elements.vue2_integration(M); context = parentmodule(M)) 
   end
   ENV["GB_ROUTES"] = true
 end
 
 function stipple_deps(::Type{M}, vue_app_name, debounce, throttle, core_theme, endpoint, transport)::Function where {M<:ReactiveModel}
   () -> begin
+    context = parentmodule(M)
     if ! Genie.Assets.external_assets(assets_config)
       if ! Genie.Router.isroute(Symbol(routename(M)))
-        Genie.Router.route(Genie.Assets.asset_route(assets_config, :js, file = endpoint), named = Symbol(routename(M))) do
-          Stipple.Elements.vue_integration(M; vue_app_name, debounce, throttle, core_theme, transport) |> Genie.Renderer.Js.js
+        Genie.Router.route(Genie.Assets.asset_route(assets_config, :js, file = endpoint), named = Symbol(routename(M))) do 
+          Genie.Renderer.Js.js(Stipple.Elements.vue_integration(M; vue_app_name, debounce, throttle, core_theme, transport); context)
         end
       end
     end
@@ -774,7 +775,7 @@ function stipple_deps(::Type{M}, vue_app_name, debounce, throttle, core_theme, e
         Genie.Renderer.Html.script(src = Genie.Assets.asset_path(assets_config, :js, file = vue_app_name), defer = true)
       else
         Genie.Renderer.Html.script([
-          (Stipple.Elements.vue_integration(M; vue_app_name, debounce, throttle, core_theme, transport) |> Genie.Renderer.Js.js).body |> String
+          Genie.Renderer.Js.js(Stipple.Elements.vue_integration(M; vue_app_name, debounce, throttle, core_theme, transport); context).body |> String
         ])
       end
     ]

--- a/src/Tools.jl
+++ b/src/Tools.jl
@@ -205,7 +205,7 @@ macro stipple_precompile(setup, workload)
                 precompile_post(location::String, args...; kwargs...) = precompile_request(:POST, location, args...; kwargs...)
 
                 Stipple.Logging.with_logger(Stipple.Logging.SimpleLogger(stdout, Stipple.Logging.Error)) do
-                    Stipple.up(port)
+                    Stipple.up(host = "127.0.0.1", port = port, wsport = port)
 
                     $workload
 
@@ -321,3 +321,13 @@ end
 
 debug(model::ReactiveModel, field::Symbol; listener::Int = 0) = debug(getfield(model, field); listener)
 debug(model::ReactiveModel, field::Symbol, value; listener::Int = 0) = debug(getfield(model, field), value; listener)
+
+# add method to get JS asset path for a ReactiveModel type
+function Genie.Assets.asset_path(::Type{App}) where App <: ReactiveModel
+    Genie.Assets.asset_path(Stipple.assets_config, :js; file = vm(App))
+end
+
+# utility function to get content from local server
+function hget(s::AbstractString = "/")
+    try HTTP.get("http://localhost:$(Genie.config.server_port)/" * strip(s, '/'), retry = false).body |> String catch; nothing end
+end


### PR DESCRIPTION
Currently, precompilation of an app's js asset path, e.g. `mymodule_myapp.js`, fails with an error that content could not be precompiled into the module Genie.Renderer.Js.
The root cause is that `Stipple.Elements.vue_integration` called Genie.Renderer.JS.js without a context. Supplying the app's context makes it work when Genie's build path is set to a non-temp directory.
With that done - have a look at https://github.com/GenieFramework/StippleDemos/tree/master/AdvancedExamples/GenieTemplate - the duration from start to the loaded webpage is 4-5 seconds on my windows machine.